### PR TITLE
【晴】記事いいね

### DIFF
--- a/src/tufspot/app/Http/Controllers/UserController.php
+++ b/src/tufspot/app/Http/Controllers/UserController.php
@@ -22,17 +22,17 @@ class UserController extends Controller
     {
         // 管理者かつ記事を持っている(公開済み)ユーザーのみ表示（ユーザー一覧でもやる）
         $user = User::with('posts')->where([
-                ['id', '=', $user['id']],
-                ['role', '=', 1],
-            ])->whereHas('posts', function($q){
-                $q->whereExists(function($q){
-                    return $q;
-                });
-            })->first();
+            ['id', '=', $user['id']],
+            ['role', '=', 1],
+        ])->whereHas('posts', function ($q) {
+            $q->whereExists(function ($q) {
+                return $q;
+            });
+        })->first();
         if (empty($user)) {
             abort(404, '存在しないページです');
-        }        
-        
+        }
+
         // TODO: 執筆記事取得 仮で適当に取得
         $written_posts = Post::latest()->take(6)->get();
         return view('writer_detail', compact('user', 'written_posts'));
@@ -49,14 +49,14 @@ class UserController extends Controller
         $public = 1;
         // TODO: ページネーションで一度に表示人数絞る
         $writers = User::where([
-                        ['role', '=', 1],
-                    ])->with(['posts' => function ($query) use ($public) {
-                        $query->where('is_public', $public);
-                    }])->whereHas('posts', function($query){
-                        $query->whereExists(function($query){
-                            return $query;
-                        });
-                    })->get();
+            ['role', '=', 1],
+        ])->with(['posts' => function ($query) use ($public) {
+            $query->where('is_public', $public);
+        }])->whereHas('posts', function ($query) {
+            $query->whereExists(function ($query) {
+                return $query;
+            });
+        })->get();
         return view('writer_list', compact('writers'));
     }
 
@@ -73,24 +73,24 @@ class UserController extends Controller
         $user['phone_number'] = $user->gaigokaiMembers[0]['phone_number'];
 
         // タグ検索していないためnull
-        $tagSlug =null;
-        // TODO: お気に入り記事（保存記事）仮で適当に取得
-        $favorited_posts = Post::PublicList($tagSlug)->take(6)->get();
+        $tagSlug = null;
+        // TODO: お気に入りはひとまず6件だけ取得、必要ならあとからPagination追加
+        $liked_posts = $user->likes()->take(6)->get();
         // TODO: 閲覧履歴 仮で適当に取得
         $history_posts = Post::PublicList($tagSlug)->take(6)->get();
         // TODO: フォロー済みライター(管理者かつ記事持ってる) 仮で適当に取得
         $public = 1;
         $follow_writers = User::where([
-                            ['role', '=', 1],
-                        ])->with(['posts' => function ($query) use ($public) {
-                            $query->where('is_public', $public);
-                        }])->whereHas('posts', function($query){
-                            $query->whereExists(function($query){
-                                return $query;
-                            });
-                        })->get();
+            ['role', '=', 1],
+        ])->with(['posts' => function ($query) use ($public) {
+            $query->where('is_public', $public);
+        }])->whereHas('posts', function ($query) {
+            $query->whereExists(function ($query) {
+                return $query;
+            });
+        })->get();
 
-        return view('mypage', compact('user', 'favorited_posts', 'history_posts', 'follow_writers'));
+        return view('mypage', compact('user', 'liked_posts', 'history_posts', 'follow_writers'));
     }
 
     /**

--- a/src/tufspot/app/Livewire/Like.php
+++ b/src/tufspot/app/Livewire/Like.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace App\Livewire;
+
+use Livewire\Component;
+
+class Like extends Component
+{
+    public function render()
+    {
+        return view('livewire.like');
+    }
+}

--- a/src/tufspot/app/Livewire/Like.php
+++ b/src/tufspot/app/Livewire/Like.php
@@ -2,10 +2,22 @@
 
 namespace App\Livewire;
 
+use App\Models\Post;
+use App\Models\User;
+use Illuminate\Support\Facades\Auth;
 use Livewire\Component;
 
 class Like extends Component
 {
+    public Post $post;
+    public User $user;
+
+    public function like()
+    {
+        $this->user = Auth::user();
+        $this->user->likes()->toggle($this->post->id);
+    }
+
     public function render()
     {
         return view('livewire.like');

--- a/src/tufspot/app/Models/Post.php
+++ b/src/tufspot/app/Models/Post.php
@@ -29,7 +29,7 @@ class Post extends Model
 
         return $query;
     }
-    
+
     protected static function boot()
     {
         parent::boot();
@@ -65,6 +65,16 @@ class Post extends Model
     public function categories()
     {
         return $this->belongsToMany(Category::class);
+    }
+
+    /**
+     * いいねのリレーション
+     *
+     * @return \Illuminate\Database\Eloquent\Relations\BelongsToMany
+     */
+    public function likes()
+    {
+        return $this->belongsToMany(User::class, 'likes', 'post_id', 'user_id');
     }
 
     /**

--- a/src/tufspot/app/Models/User.php
+++ b/src/tufspot/app/Models/User.php
@@ -100,6 +100,16 @@ class User extends Authenticatable
     }
 
     /**
+     * いいねのリレーション
+     *
+     * @return \Illuminate\Database\Eloquent\Relations\BelongsToMany
+     */
+    public function likes()
+    {
+        return $this->belongsToMany(Post::class, 'likes', 'user_id', 'post_id');
+    }
+
+    /**
      * 権限をラベル表示
      *
      * @return string

--- a/src/tufspot/composer.json
+++ b/src/tufspot/composer.json
@@ -15,7 +15,8 @@
         "laravel/sanctum": "^3.2",
         "laravel/tinker": "^2.8",
         "laravel/ui": "^4.2",
-        "laravelcollective/html": "^6.4"
+        "laravelcollective/html": "^6.4",
+        "livewire/livewire": "^3.0"
     },
     "require-dev": {
         "fakerphp/faker": "^1.9.1",

--- a/src/tufspot/composer.lock
+++ b/src/tufspot/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "cf08b4ba1e63829737258115039879df",
+    "content-hash": "2017d4580f1d7f31daada8295f1e888f",
     "packages": [
         {
             "name": "almasaeed2010/adminlte",
@@ -1997,6 +1997,80 @@
                 }
             ],
             "time": "2022-04-17T13:12:02+00:00"
+        },
+        {
+            "name": "livewire/livewire",
+            "version": "v3.0.5",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/livewire/livewire.git",
+                "reference": "37f11583c61a75d51b2146c2fe38f506ad36014b"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/livewire/livewire/zipball/37f11583c61a75d51b2146c2fe38f506ad36014b",
+                "reference": "37f11583c61a75d51b2146c2fe38f506ad36014b",
+                "shasum": ""
+            },
+            "require": {
+                "illuminate/database": "^10.0",
+                "illuminate/support": "^10.0",
+                "illuminate/validation": "^10.0",
+                "league/mime-type-detection": "^1.9",
+                "php": "^8.1",
+                "symfony/http-kernel": "^5.0|^6.0"
+            },
+            "require-dev": {
+                "calebporzio/sushi": "^2.1",
+                "laravel/framework": "^10.0",
+                "laravel/prompts": "^0.1.6",
+                "mockery/mockery": "^1.3.1",
+                "orchestra/testbench": "^7.0|^8.0",
+                "orchestra/testbench-dusk": "^7.0|^8.0",
+                "phpunit/phpunit": "^9.0",
+                "psy/psysh": "@stable"
+            },
+            "type": "library",
+            "extra": {
+                "laravel": {
+                    "providers": [
+                        "Livewire\\LivewireServiceProvider"
+                    ],
+                    "aliases": {
+                        "Livewire": "Livewire\\Livewire"
+                    }
+                }
+            },
+            "autoload": {
+                "files": [
+                    "src/helpers.php"
+                ],
+                "psr-4": {
+                    "Livewire\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Caleb Porzio",
+                    "email": "calebporzio@gmail.com"
+                }
+            ],
+            "description": "A front-end framework for Laravel.",
+            "support": {
+                "issues": "https://github.com/livewire/livewire/issues",
+                "source": "https://github.com/livewire/livewire/tree/v3.0.5"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/livewire",
+                    "type": "github"
+                }
+            ],
+            "time": "2023-09-16T11:51:32+00:00"
         },
         {
             "name": "monolog/monolog",
@@ -8188,5 +8262,5 @@
         "php": "^8.1"
     },
     "platform-dev": [],
-    "plugin-api-version": "2.3.0"
+    "plugin-api-version": "2.6.0"
 }

--- a/src/tufspot/database/migrations/2023_09_23_025355_create_likes_table.php
+++ b/src/tufspot/database/migrations/2023_09_23_025355_create_likes_table.php
@@ -1,0 +1,29 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('likes', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('user_id')->constrained()->cascadeOnDelete();
+            $table->foreignId('post_id')->constrained()->cascadeOnDelete();
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('likes');
+    }
+};

--- a/src/tufspot/database/seeds/PostSeeder.php
+++ b/src/tufspot/database/seeds/PostSeeder.php
@@ -17,5 +17,28 @@ class PostSeeder extends Seeder
         \Event::fakeFor(function () {
             Post::factory()->count(50)->create();
         });
+
+        \DB::table('likes')->insert([
+            [
+                'user_id' => 2,
+                'post_id' => 1,
+            ],
+            [
+                'user_id' => 2,
+                'post_id' => 2,
+            ],
+            [
+                'user_id' => 2,
+                'post_id' => 3,
+            ],
+            [
+                'user_id' => 2,
+                'post_id' => 4,
+            ],
+            [
+                'user_id' => 2,
+                'post_id' => 5,
+            ],
+        ]);
     }
 }

--- a/src/tufspot/resources/views/components/template.blade.php
+++ b/src/tufspot/resources/views/components/template.blade.php
@@ -26,6 +26,8 @@
     <link href="{{ asset('css/post.css') }}" rel="stylesheet">
     {{-- 目次生成 --}}
     <link rel="stylesheet" type="text/css" href="{{ asset('css/mokuji.css') }}">
+
+    @livewireStyles
 </head>
 
 <body alink=”#0056b3 class="body">
@@ -95,6 +97,8 @@
             });
         }
     </script>
+
+    @livewireScripts
 </body>
 
 </html>

--- a/src/tufspot/resources/views/livewire/like.blade.php
+++ b/src/tufspot/resources/views/livewire/like.blade.php
@@ -1,13 +1,13 @@
 <div>
-    <span wire:click="like">
+    <button wire:click="like" class="border-0 bg-transparent">
         @if ($post->isLiked())
             <svg xmlns="http://www.w3.org/2000/svg" width="30" height="30" fill="currentColor" class="bi bi-heart-fill text-danger" viewBox="0 0 16 16">
                 <path fill-rule="evenodd" d="M8 1.314C12.438-3.248 23.534 4.735 8 15-7.534 4.736 3.562-3.248 8 1.314z" />
             </svg>
         @else
-            <svg xmlns="http://www.w3.org/2000/svg" width="30" height="30" fill="currentColor" class="bi bi-heart" viewBox="0 0 16 16">
+            <svg xmlns="http://www.w3.org/2000/svg" width="30" height="30" fill="currentColor" class="bi bi-heart text-danger" viewBox="0 0 16 16">
                 <path d="m8 2.748-.717-.737C5.6.281 2.514.878 1.4 3.053c-.523 1.023-.641 2.5.314 4.385.92 1.815 2.834 3.989 6.286 6.357 3.452-2.368 5.365-4.542 6.286-6.357.955-1.886.838-3.362.314-4.385C13.486.878 10.4.28 8.717 2.01L8 2.748zM8 15C-7.333 4.868 3.279-3.04 7.824 1.143c.06.055.119.112.176.171a3.12 3.12 0 0 1 .176-.17C12.72-3.042 23.333 4.867 8 15z" />
             </svg>
         @endif
-    </span>
+    </button>
 </div>

--- a/src/tufspot/resources/views/livewire/like.blade.php
+++ b/src/tufspot/resources/views/livewire/like.blade.php
@@ -1,3 +1,13 @@
 <div>
-    <h1>This is Livewire</h1>
+    <span wire:click="like">
+        @if ($post->isLiked())
+            <svg xmlns="http://www.w3.org/2000/svg" width="30" height="30" fill="currentColor" class="bi bi-heart-fill text-danger" viewBox="0 0 16 16">
+                <path fill-rule="evenodd" d="M8 1.314C12.438-3.248 23.534 4.735 8 15-7.534 4.736 3.562-3.248 8 1.314z" />
+            </svg>
+        @else
+            <svg xmlns="http://www.w3.org/2000/svg" width="30" height="30" fill="currentColor" class="bi bi-heart" viewBox="0 0 16 16">
+                <path d="m8 2.748-.717-.737C5.6.281 2.514.878 1.4 3.053c-.523 1.023-.641 2.5.314 4.385.92 1.815 2.834 3.989 6.286 6.357 3.452-2.368 5.365-4.542 6.286-6.357.955-1.886.838-3.362.314-4.385C13.486.878 10.4.28 8.717 2.01L8 2.748zM8 15C-7.333 4.868 3.279-3.04 7.824 1.143c.06.055.119.112.176.171a3.12 3.12 0 0 1 .176-.17C12.72-3.042 23.333 4.867 8 15z" />
+            </svg>
+        @endif
+    </span>
 </div>

--- a/src/tufspot/resources/views/livewire/like.blade.php
+++ b/src/tufspot/resources/views/livewire/like.blade.php
@@ -1,0 +1,3 @@
+<div>
+    <h1>This is Livewire</h1>
+</div>

--- a/src/tufspot/resources/views/mypage.blade.php
+++ b/src/tufspot/resources/views/mypage.blade.php
@@ -35,7 +35,7 @@
                 </div>
                 <div id="panel2" class="tab_panel2">
                     <div class="d-flex justify-content-center flex-wrap">
-                        @foreach ($favorited_posts as $post)
+                        @foreach ($liked_posts as $post)
                             <x-post_card :post=$post />
                         @endforeach
                         {{-- <x-post_card place="ハロン湾" />

--- a/src/tufspot/resources/views/post_detail.blade.php
+++ b/src/tufspot/resources/views/post_detail.blade.php
@@ -13,9 +13,7 @@
                         <div class="post-title d-flex justify-content-between ">
                         <div class="post-title-text">{{ $post->title }}</div>
                         <div class="post-title-icon d-flex align-items-start"> --}}
-                    <svg xmlns="http://www.w3.org/2000/svg" width="30" height="30" fill="currentColor" class="bi bi-heart" viewBox="0 0 16 16">
-                        <path d="m8 2.748-.717-.737C5.6.281 2.514.878 1.4 3.053c-.523 1.023-.641 2.5.314 4.385.92 1.815 2.834 3.989 6.286 6.357 3.452-2.368 5.365-4.542 6.286-6.357.955-1.886.838-3.362.314-4.385C13.486.878 10.4.28 8.717 2.01L8 2.748zM8 15C-7.333 4.868 3.279-3.04 7.824 1.143c.06.055.119.112.176.171a3.12 3.12 0 0 1 .176-.17C12.72-3.042 23.333 4.867 8 15z" />
-                    </svg>
+                    <livewire:like :post="$post" />
                     <svg xmlns="http://www.w3.org/2000/svg" width="30" height="30" fill="currentColor" class="bi bi-three-dots" viewBox="0 0 16 16">
                         <path d="M3 9.5a1.5 1.5 0 1 1 0-3 1.5 1.5 0 0 1 0 3zm5 0a1.5 1.5 0 1 1 0-3 1.5 1.5 0 0 1 0 3zm5 0a1.5 1.5 0 1 1 0-3 1.5 1.5 0 0 1 0 3z" />
                     </svg>

--- a/src/tufspot/resources/views/post_detail.blade.php
+++ b/src/tufspot/resources/views/post_detail.blade.php
@@ -14,7 +14,7 @@
                         <div class="post-title-text">{{ $post->title }}</div>
                         <div class="post-title-icon d-flex align-items-start"> --}}
                     <livewire:like :post="$post" />
-                    <svg xmlns="http://www.w3.org/2000/svg" width="30" height="30" fill="currentColor" class="bi bi-three-dots" viewBox="0 0 16 16">
+                    <svg xmlns="http://www.w3.org/2000/svg" width="30" height="30" fill="currentColor" class="bi bi-three-dots ms-2" viewBox="0 0 16 16">
                         <path d="M3 9.5a1.5 1.5 0 1 1 0-3 1.5 1.5 0 0 1 0 3zm5 0a1.5 1.5 0 1 1 0-3 1.5 1.5 0 0 1 0 3zm5 0a1.5 1.5 0 1 1 0-3 1.5 1.5 0 0 1 0 3z" />
                     </svg>
                 </div>

--- a/src/tufspot/resources/views/post_detail.blade.php
+++ b/src/tufspot/resources/views/post_detail.blade.php
@@ -50,7 +50,7 @@
             </div>
             {{-- Quillと代替ここから --}}
             {{-- <div class="post-detail-list">
-                ボーダー用pタグ 
+                ボーダー用pタグ
                 <p class="post-detail-border"></p>
                 <div class="post-detail-explain-text-wrapper">
                     <p class="post-detail-explain-text">


### PR DESCRIPTION
# いいね機能作成

## 概要
- ログインユーザーが記事をいいね可能
- Livewireで実装
- いいねされている状態：赤ハート、いいねされていない状態：白ハート
- いいねした記事はMypageの保存記事一覧にて表示
- PostSeederにて、いいねのダミーを追加

## TODO
- Mypageには6件のみ取得して表示しているため、必要があればPaginationの追加

## マージ時にやったこと
- npm install
- npm update
- キャッシュクリア
php artisan cache:clear
php artisan config:clear
php artisan route:clear
php artisan view:clear