### PR TITLE
Feature/feature public【晴】特集の公開・非公開を選択可能に

### DIFF
--- a/src/tufspot/app/Models/Feature.php
+++ b/src/tufspot/app/Models/Feature.php
@@ -10,7 +10,7 @@ class Feature extends Model
     use HasFactory;
 
     protected $fillable = [
-        'slug', 'name', 'description'
+        'slug', 'name', 'description', 'is_public'
     ];
 
     /**

--- a/src/tufspot/database/migrations/2020_11_14_171435_create_features_table.php
+++ b/src/tufspot/database/migrations/2020_11_14_171435_create_features_table.php
@@ -18,7 +18,7 @@ class CreateFeaturesTable extends Migration
             $table->string('slug')->unique();
             $table->string('name');
             $table->text('description')->nullable();
-            $table->boolean('is_public')->default(true)->comment('公開・非公開');
+            $table->boolean('is_public')->comment('公開・非公開');
             $table->timestamps();
         });
 

--- a/src/tufspot/database/migrations/2020_11_14_171435_create_features_table.php
+++ b/src/tufspot/database/migrations/2020_11_14_171435_create_features_table.php
@@ -18,6 +18,7 @@ class CreateFeaturesTable extends Migration
             $table->string('slug')->unique();
             $table->string('name');
             $table->text('description')->nullable();
+            $table->boolean('is_public')->default(true)->comment('公開・非公開');
             $table->timestamps();
         });
 

--- a/src/tufspot/database/seeds/FeatureSeeder.php
+++ b/src/tufspot/database/seeds/FeatureSeeder.php
@@ -20,6 +20,7 @@ class FeatureSeeder extends Seeder
                 'name' => '注目記事',
                 'slug' => 'pickup',
                 'description' => $faker->realText(rand(100, 200)),
+                'is_public' => 1,
                 'created_at' => now(),
                 'updated_at' => now()
             ],
@@ -27,18 +28,21 @@ class FeatureSeeder extends Seeder
                 'name' => 'アジア特集',
                 'slug' => 'asia',
                 'description' => $faker->realText(rand(100, 200)),
+                'is_public' => 1,
                 'created_at' => now(),
                 'updated_at' => now()
             ], [
                 'name' => '大阪万博',
                 'slug' => 'osaka-expo',
                 'description' => $faker->realText(rand(100, 200)),
+                'is_public' => 1,
                 'created_at' => now(),
                 'updated_at' => now()
             ], [
                 'name' => '外語祭関連',
                 'slug' => 'gaigosai',
                 'description' => $faker->realText(rand(100, 200)),
+                'is_public' => 1,
                 'created_at' => now(),
                 'updated_at' => now()
             ]

--- a/src/tufspot/resources/views/back/features/_form.blade.php
+++ b/src/tufspot/resources/views/back/features/_form.blade.php
@@ -135,7 +135,8 @@
     <div class="col post-form-col">
         @foreach (config('common.public_status') as $key => $value)
             <div class="form-check form-check-inline">
-                {{ Form::radio('is_public', $key, $key === 1 ? true : false, [
+                {{-- 特集作成時のみ公開にデフォルトでチェックを入れておく --}}
+                {{ Form::radio('is_public', $key, Route::is('back.features.create') && $key === 1 ? true : null, [
                     'id' => 'is_public' . $key,
                     'class' => 'form-check-input' . ($errors->has('is_public') ? ' is-invalid' : ''),
                 ]) }}

--- a/src/tufspot/resources/views/back/features/_form.blade.php
+++ b/src/tufspot/resources/views/back/features/_form.blade.php
@@ -130,6 +130,27 @@
     </div> --}}
 @endif
 
+<div class="form-group row">
+    {{ Form::label('is_public', '状態', ['class' => 'col-sm-1 col-form-label w-auto post-form']) }}
+    <div class="col post-form-col">
+        @foreach (config('common.public_status') as $key => $value)
+            <div class="form-check form-check-inline">
+                {{ Form::radio('is_public', $key, $key === 1 ? true : false, [
+                    'id' => 'is_public' . $key,
+                    'class' => 'form-check-input' . ($errors->has('is_public') ? ' is-invalid' : ''),
+                ]) }}
+                {{ Form::label('is_public' . $key, $value, ['class' => 'form-check-label']) }}
+                @if ($key === 1)
+                    @error('is_public')
+                        <div class="text-danger form-check form-check-inline">
+                            {{ $message }}
+                        </div>
+                    @enderror
+                @endif
+            </div>
+        @endforeach
+    </div>
+</div>
 
 <div class="form-group row">
     <div class="col-sm-10">

--- a/src/tufspot/resources/views/category.blade.php
+++ b/src/tufspot/resources/views/category.blade.php
@@ -21,17 +21,20 @@
         @endforeach
         @foreach ($features as $feature)
             {{-- <div class="feature_box" id="makeImg"></div> --}}
-            <div class="post_list_explain d-flex flex-column justify-content-center">
-                <a class="text-decoration-none gray_color" href="{{ route('category_detail', ['feature', $feature->slug]) }}">
-                    <h2 class="text-center mb-4 gray_color">{{ $feature->name }}</h2>
-                    <p class="post_list_explain_text m-0">
-                        {!! nl2br($feature->description) !!}
-                        {{-- ここに記事が書かれます。ここに記事が書かれます。ここに記事が書かれます。ここに記事が書かれます。
+            {{-- 公開中のみ表示 --}}
+            @if ($feature->is_public)
+                <div class="post_list_explain d-flex flex-column justify-content-center">
+                    <a class="text-decoration-none gray_color" href="{{ route('category_detail', ['feature', $feature->slug]) }}">
+                        <h2 class="text-center mb-4 gray_color">{{ $feature->name }}</h2>
+                        <p class="post_list_explain_text m-0">
+                            {!! nl2br($feature->description) !!}
+                            {{-- ここに記事が書かれます。ここに記事が書かれます。ここに記事が書かれます。ここに記事が書かれます。
                 ここに記事が書かれます。ここに記事が書かれます。ここに記事が書かれます。ここに記事が書かれます。
                 ここに記事が書かれます。ここに記事が書かれます。ここに記事が書かれます。ここに記事が書かれます。 --}}
-                    </p>
-                </a>
-            </div>
+                        </p>
+                    </a>
+                </div>
+            @endif
         @endforeach
 
         {{-- <div class="feature_box" id="makeImg">


### PR DESCRIPTION
# 特集の公開・非公開を選択可能に

## 詳細
- Featureのtableにis_publicを追加
  - 特集作成時に公開・非公開を選択するため、デフォルト値は持たない
- 特集作成ページと特集編集ページにラジオボタンを設置
  - 作成ページではデフォルトで公開にチェック
  - 編集ページでは現在の状況に応じてチェック
- エンドユーザー側で、公開中特集のみ表示されるように設定

## 備考
- スタイリングは記事作成フォームからパクったため適当