### PR TITLE
【晴】カテゴリの公開・非公開を選択可能に

### DIFF
--- a/src/tufspot/app/Http/Controllers/PostController.php
+++ b/src/tufspot/app/Http/Controllers/PostController.php
@@ -54,23 +54,37 @@ class PostController extends Controller
         // 特集項目を選択する？特集全体からランダム？一旦全体からランダム
         $feature_posts = Post::PublicList($this->tagSlug, $this->categorySlug, $this->featureSlug)->inRandomOrder()->take(10)->get();
 
+        // TODO: Category::NAMEよりもCategory::IDの方が直感的な気がする、影響範囲が不明のためいったん放置
+        // 公開・非公開の出し分けはview側でもできるが、Controller内の方が無駄なクエリを発行せずに済みそう
         $academia_category_id = Category::NAME['Academia'];
         $academia_category = Category::find($academia_category_id);
-        $academia_posts = Post::PublicList($this->tagSlug, $this->categorySlug, $this->featureSlug)->whereHas('categories', function ($query) use ($academia_category_id) {
-            $query->where('category_id', $academia_category_id);
-        })->take(12)->get();
+        $is_academia_public = $academia_category->is_public;
+        $academia_posts = null;
+        if ($is_academia_public) {
+            $academia_posts = Post::PublicList($this->tagSlug, $this->categorySlug, $this->featureSlug)->whereHas('categories', function ($query) use ($academia_category_id) {
+                $query->where('category_id', $academia_category_id);
+            })->take(12)->get();
+        }
 
         $business_category_id = Category::NAME['Business'];
         $business_category = Category::find($business_category_id);
-        $business_posts = Post::PublicList($this->tagSlug, $this->categorySlug, $this->featureSlug)->whereHas('categories', function ($query) use ($business_category_id) {
-            $query->where('category_id', $business_category_id);
-        })->take(12)->get();
+        $is_business_public = $business_category->is_public;
+        $business_posts = null;
+        if ($is_business_public) {
+            $business_posts = Post::PublicList($this->tagSlug, $this->categorySlug, $this->featureSlug)->whereHas('categories', function ($query) use ($business_category_id) {
+                $query->where('category_id', $business_category_id);
+            })->take(12)->get();
+        }
 
         $culture_category_id = Category::NAME['Culture'];
         $culture_category = Category::find($culture_category_id);
-        $culture_posts = Post::PublicList($this->tagSlug, $this->categorySlug, $this->featureSlug)->whereHas('categories', function ($query) use ($culture_category_id) {
-            $query->where('category_id', $culture_category_id);
-        })->take(12)->get();
+        $is_culture_public = $culture_category->is_public;
+        $culture_posts = null;
+        if ($is_culture_public) {
+            $culture_posts = Post::PublicList($this->tagSlug, $this->categorySlug, $this->featureSlug)->whereHas('categories', function ($query) use ($culture_category_id) {
+                $query->where('category_id', $culture_category_id);
+            })->take(12)->get();
+        }
 
         $search = $request->all();
         $users = User::pluck('name', 'id')->toArray();

--- a/src/tufspot/app/Models/Category.php
+++ b/src/tufspot/app/Models/Category.php
@@ -10,7 +10,7 @@ class Category extends Model
     use HasFactory;
 
     protected $fillable = [
-        'slug', 'name', 'description'
+        'slug', 'name', 'description', 'is_public'
     ];
 
     const NAME = [

--- a/src/tufspot/database/migrations/2020_11_15_171547_create_categories_table.php
+++ b/src/tufspot/database/migrations/2020_11_15_171547_create_categories_table.php
@@ -1,4 +1,5 @@
 <?php
+
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
@@ -17,6 +18,7 @@ class CreateCategoriesTable extends Migration
             $table->string('slug')->unique();
             $table->string('name');
             $table->text('description')->nullable();
+            $table->boolean('is_public')->comment('公開・非公開');
             $table->timestamps();
         });
 

--- a/src/tufspot/database/seeds/CategorySeeder.php
+++ b/src/tufspot/database/seeds/CategorySeeder.php
@@ -19,19 +19,22 @@ class CategorySeeder extends Seeder
             [
                 'name' => 'Academia',
                 'slug' => 'academia',
-                'description' => $faker->realText(rand(100,200)),
+                'description' => $faker->realText(rand(100, 200)),
+                'is_public' => 1,
                 'created_at' => now(),
                 'updated_at' => now()
-            ],[
+            ], [
                 'name' => 'Business and Career',
                 'slug' => 'business-and-career',
-                'description' => $faker->realText(rand(100,200)),
+                'description' => $faker->realText(rand(100, 200)),
+                'is_public' => 1,
                 'created_at' => now(),
                 'updated_at' => now()
-            ],[
+            ], [
                 'name' => 'Culture and Essay',
                 'slug' => 'culture-and-essay',
-                'description' => $faker->realText(rand(100,200)),
+                'description' => $faker->realText(rand(100, 200)),
+                'is_public' => 1,
                 'created_at' => now(),
                 'updated_at' => now()
             ]
@@ -40,7 +43,7 @@ class CategorySeeder extends Seeder
         for ($i = 1; $i <= 50; $i++) {
             \DB::table('category_post')->insert([
                 'post_id' => $i,
-                'category_id' => $faker->numberBetween(1,3)
+                'category_id' => $faker->numberBetween(1, 3)
             ]);
         }
     }

--- a/src/tufspot/resources/views/back/categories/_form.blade.php
+++ b/src/tufspot/resources/views/back/categories/_form.blade.php
@@ -128,6 +128,30 @@
         {{ $posts->appends($search)->links() }}
     </div> --}}
 @endif
+
+<div class="form-group row">
+    {{ Form::label('is_public', '状態', ['class' => 'col-sm-1 col-form-label w-auto post-form']) }}
+    <div class="col post-form-col">
+        @foreach (config('common.public_status') as $key => $value)
+            <div class="form-check form-check-inline">
+                {{-- カテゴリー作成時のみ公開にデフォルトでチェックを入れておく --}}
+                {{ Form::radio('is_public', $key, Route::is('back.categories.create') && $key === 1 ? true : null, [
+                    'id' => 'is_public' . $key,
+                    'class' => 'form-check-input' . ($errors->has('is_public') ? ' is-invalid' : ''),
+                ]) }}
+                {{ Form::label('is_public' . $key, $value, ['class' => 'form-check-label']) }}
+                @if ($key === 1)
+                    @error('is_public')
+                        <div class="text-danger form-check form-check-inline">
+                            {{ $message }}
+                        </div>
+                    @enderror
+                @endif
+            </div>
+        @endforeach
+    </div>
+</div>
+
 <div class="form-group row">
     <div class="col-sm-10">
         <button type="submit" class="btn btn-primary">保存</button>

--- a/src/tufspot/resources/views/category.blade.php
+++ b/src/tufspot/resources/views/category.blade.php
@@ -6,18 +6,21 @@
     <x-main>
         {{-- TODO: 特集一覧（〇〇特集, ✖️✖️特集, △△特集,,,を全て表示して、それぞれのまとめへ遷移） --}}
         @foreach ($categories as $category)
-            {{-- <div class="feature_box" id="makeImg"></div> --}}
-            <div class="mt-5 post_list_explain d-flex flex-column justify-content-center">
-                <a class="text-decoration-none gray_color" href="{{ route('category_detail', ['category', $category->slug]) }}">
-                    <h2 class="text-center mb-5 gray_color">{{ $category->name }}</h2>
-                    <p class="post_list_explain_text m-0">
-                        {!! nl2br($category->description) !!}
-                        {{-- ここに記事が書かれます。ここに記事が書かれます。ここに記事が書かれます。ここに記事が書かれます。
+            {{-- 公開中のみ表示 --}}
+            @if ($category->is_public)
+                {{-- <div class="feature_box" id="makeImg"></div> --}}
+                <div class="mt-5 post_list_explain d-flex flex-column justify-content-center">
+                    <a class="text-decoration-none gray_color" href="{{ route('category_detail', ['category', $category->slug]) }}">
+                        <h2 class="text-center mb-5 gray_color">{{ $category->name }}</h2>
+                        <p class="post_list_explain_text m-0">
+                            {!! nl2br($category->description) !!}
+                            {{-- ここに記事が書かれます。ここに記事が書かれます。ここに記事が書かれます。ここに記事が書かれます。
                     ここに記事が書かれます。ここに記事が書かれます。ここに記事が書かれます。ここに記事が書かれます。
                     ここに記事が書かれます。ここに記事が書かれます。ここに記事が書かれます。ここに記事が書かれます。 --}}
-                    </p>
-                </a>
-            </div>
+                        </p>
+                    </a>
+                </div>
+            @endif
         @endforeach
         @foreach ($features as $feature)
             {{-- <div class="feature_box" id="makeImg"></div> --}}


### PR DESCRIPTION
# カテゴリの公開・非公開を選択可能に

## 詳細
- Categoryのtableにis_publicを追加
  - カテゴリ作成時に公開・非公開を選択するため、デフォルト値は持たない
- カテゴリ作成ページとカテゴリ編集ページにラジオボタンを設置
  - 作成ページではデフォルトで公開にチェック
  - 編集ページでは現在の状況に応じてチェック
- エンドユーザー側のカテゴリリストページでは、公開中特集のみ表示されるように設定
- エンドユーザー側のIndexページでは、最大で3種表示。非表示することも可能。

## 備考
- スタイリングは記事作成フォームからパクったため適当
- config/commonからpublic_statusをとってきているため、フォームのラベルが"下書き"になっているが、ここは"非公開"で統一したほうが良さそう？
  - categoryとかfeatureに対して"下書き"はピンとこない