### PR TITLE
【晴】ハッシュタグ検索

### DIFF
--- a/src/tufspot/app/Http/Controllers/PostController.php
+++ b/src/tufspot/app/Http/Controllers/PostController.php
@@ -154,6 +154,17 @@ class PostController extends Controller
         return view('search_result', compact('keywordArr'));
     }
 
+    /**
+     * ハッシュタグによる記事一覧表示
+     *
+     * @return \Illuminate\Contracts\View\View
+     */
+    public function hashtag(string $tag_slug)
+    {
+        $tag_name = Tag::where('slug', $tag_slug)->first()->name;
+        return view('hashtag_result', compact('tag_slug', 'tag_name'));
+    }
+
     // public function index(string $tagSlug = null)
     // {
     //     // 公開・新しい順に表示

--- a/src/tufspot/app/Livewire/PaginatedPostList.php
+++ b/src/tufspot/app/Livewire/PaginatedPostList.php
@@ -21,6 +21,9 @@ class PaginatedPostList extends Component
     // 検索結果表示用
     public $keywords;
 
+    // ハッシュタグ検索結果表示用
+    public $tag_slug;
+
     public User $user;
     public $per_page = 6; // ページ内の表示数調整
     public $page_flag; // どのページを表示するのか、コンポーネントを使いまわすために利用
@@ -77,6 +80,14 @@ class PaginatedPostList extends Component
 
             $posts = $query->paginate($this->per_page);
         }
+
+        // ハッシュタグ検索一覧
+        if ($this->page_flag === "hashtag") {
+            $posts = Post::whereHas('tags', function ($q) {
+                $q->where('slug', $this->tag_slug);
+            })->paginate($this->per_page);
+        }
+
         return view('livewire.paginated-post-list', compact('posts'));
     }
 }

--- a/src/tufspot/resources/views/hashtag_result.blade.php
+++ b/src/tufspot/resources/views/hashtag_result.blade.php
@@ -4,18 +4,14 @@
     <x-header />
     <x-post_list_title class="unset-shadow" listTitle="#ハッシュタグ" />
     <x-main>
-        <div class="d-flex justify-content-center flex-wrap">
-            {{-- <div class="row row-cols-3"> --}}
-            <x-post_card place="ハロン湾" />
-            <x-post_card place="スイティエン" />
-            <x-post_card place="アンコールワット" />
-            {{-- 最終行も左寄せには、空要素入れるしかなさそう https://qiita.com/QUANON/items/e14949abab3711ca8646 --}}
-            <div class="post_card">
-            </div>
-            {{-- <div class="post_card">
-            </div>
-            <div class="post_card">
-            </div> --}}
+        {{-- TODO: 検索ワードのスタイリングはいったんカテゴリーからとってきてる、要修正 --}}
+        <div class="post_list_explain d-flex flex-column justify-content-center">
+            <p class="post_list_explain_text m-0">
+                #{{ $tag_name }}
+            </p>
+        </div>
+        <div class="article-list-area">
+            <livewire:paginated-post-list :tag_slug="$tag_slug" page_flag="hashtag" />
         </div>
     </x-main>
     <x-footer />


### PR DESCRIPTION
# ハッシュタグ検索の実装

## 詳細
- ハッシュタグをクリックで、ハッシュタグで検索をかけた記事一覧ページに遷移
- Livewireでページネーションを実装


## 備考
- 遷移先のページで検索中のハッシュタグを表示しているが、スタイリングは適当
