### PR TITLE
【晴】閲覧履歴

### DIFF
--- a/src/tufspot/app/Http/Controllers/PostController.php
+++ b/src/tufspot/app/Http/Controllers/PostController.php
@@ -10,7 +10,9 @@ use App\Models\Feature;
 use App\Models\User;
 use App\Http\Requests\PostRequest;
 use App\Http\Requests\PostUpdateRequest;
+use Carbon\Carbon;
 use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Auth;
 
 class PostController extends Controller
 {
@@ -99,7 +101,17 @@ class PostController extends Controller
      */
     public function show(int $id)
     {
+        $user = Auth::user();
         $post = Post::publicFindById($id);
+
+        // 閲覧履歴の登録、更新（updated_atで管理）
+        if ($user->histories->contains($post->id)) {
+            $user->histories()->updateExistingPivot($post->id, [
+                'updated_at' => Carbon::now(),
+            ]);
+        } else {
+            $user->histories()->attach($post->id);
+        }
         // return view('front.posts.show', compact('post'));
         return view('post_detail', compact('post'));
     }

--- a/src/tufspot/app/Http/Controllers/UserController.php
+++ b/src/tufspot/app/Http/Controllers/UserController.php
@@ -62,12 +62,7 @@ class UserController extends Controller
         // formファザード用
         $user['phone_number'] = $user->gaigokaiMembers[0]['phone_number'];
 
-        // TODO: 閲覧履歴 仮で適当に取得
-        $history_posts = Post::publicList($this->tagSlug, $this->categorySlug, $this->featureSlug)->take(6)->get();
-        // TODO: とりあえずフォロー済ライターを全件取得
-        // $following_writers = $user->followings()->get();
-
-        return view('mypage', compact('user', 'history_posts'));
+        return view('mypage', compact('user'));
     }
 
     /**

--- a/src/tufspot/app/Livewire/PaginatedPostList.php
+++ b/src/tufspot/app/Livewire/PaginatedPostList.php
@@ -61,6 +61,11 @@ class PaginatedPostList extends Component
             $posts = $this->user->posts()->paginate($this->per_page);
         }
 
+        // マイページの閲覧履歴一覧
+        if ($this->page_flag === "history") {
+            $posts = $this->user->histories()->orderByPivot('updated_at', 'desc')->paginate($this->per_page);
+        }
+
         // マイページの保存記事一覧
         if ($this->page_flag === "mypage") {
             $posts = $this->user->likes()->paginate($this->per_page);

--- a/src/tufspot/app/Models/History.php
+++ b/src/tufspot/app/Models/History.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class History extends Model
+{
+    use HasFactory;
+}

--- a/src/tufspot/app/Models/Post.php
+++ b/src/tufspot/app/Models/Post.php
@@ -87,6 +87,16 @@ class Post extends Model
     }
 
     /**
+     * 閲覧履歴のリレーション
+     *
+     * @return \Illuminate\Database\Eloquent\Relations\BelongsToMany
+     */
+    public function histories()
+    {
+        return $this->belongsToMany(User::class, 'histories', 'post_id', 'user_id');
+    }
+
+    /**
      * 公開のみ表示
      *
      * @param Builder $query

--- a/src/tufspot/app/Models/User.php
+++ b/src/tufspot/app/Models/User.php
@@ -133,6 +133,16 @@ class User extends Authenticatable
     }
 
     /**
+     * 閲覧履歴のリレーション
+     *
+     * @return \Illuminate\Database\Eloquent\Relations\BelongsToMany
+     */
+    public function histories()
+    {
+        return $this->belongsToMany(Post::class, 'histories', 'user_id', 'post_id');
+    }
+
+    /**
      * 権限をラベル表示
      *
      * @return string

--- a/src/tufspot/app/Models/User.php
+++ b/src/tufspot/app/Models/User.php
@@ -139,7 +139,7 @@ class User extends Authenticatable
      */
     public function histories()
     {
-        return $this->belongsToMany(Post::class, 'histories', 'user_id', 'post_id');
+        return $this->belongsToMany(Post::class, 'histories', 'user_id', 'post_id')->withTimestamps();
     }
 
     /**

--- a/src/tufspot/database/migrations/2023_10_01_133026_create_histories_table.php
+++ b/src/tufspot/database/migrations/2023_10_01_133026_create_histories_table.php
@@ -1,0 +1,31 @@
+<?php
+
+use App\Models\Post;
+use App\Models\User;
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('histories', function (Blueprint $table) {
+            $table->id();
+            $table->foreignIdFor(User::class)->constrained()->cascadeOnDelete();
+            $table->foreignIdFor(Post::class)->constrained()->cascadeOnDelete();
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('histories');
+    }
+};

--- a/src/tufspot/resources/views/mypage.blade.php
+++ b/src/tufspot/resources/views/mypage.blade.php
@@ -37,17 +37,7 @@
                     <livewire:paginated-post-list :user="$user" page_flag="mypage" />
                 </div>
                 <div id="panel3" class="tab_panel3">
-                    <div class="d-flex justify-content-center flex-wrap">
-                        @foreach ($history_posts as $post)
-                            <x-post_card :post=$post />
-                        @endforeach
-                        {{-- <x-post_card place="ハロン湾" />
-                        <x-post_card place="スイティエン" />
-                        <x-post_card place="アンコールワット" />
-                        <x-post_card place="ハロン湾" />
-                        <x-post_card place="スイティエン" />
-                        <x-post_card place="アンコールワット" /> --}}
-                    </div>
+                    <livewire:paginated-post-list :user="$user" page_flag="history" />
                 </div>
                 <div id="panel4" class="tab_panel4">
                     <livewire:following-writer-list :user="$user" />


### PR DESCRIPTION
# 閲覧履歴の実装

## 詳細
- histoiesテーブル（中間テーブル）を作って対応
- 閲覧履歴は中間テーブルのupdated_atカラムで管理する
- 履歴の保持数は現状12件、コントローラー内の定数変更で自由に変更可能
- 履歴表示はLivewireでページネーション

## 備考
- 履歴削除ボタンは後付け可能、リレーションをdetachするだけ
- 時間経過で履歴を消したい場合は別対応
- 履歴の保持数はデフォルト値を設定しておいて、ユーザー側で設定してもらうのもあり？