### PR TITLE
【纉】writer詳細のSNS部分のレスポンシブ崩れ

### DIFF
--- a/src/tufspot/public/css/style_uru.css
+++ b/src/tufspot/public/css/style_uru.css
@@ -515,13 +515,37 @@ input[type="radio"] {
 
 .writer-detail-sns-text {
   color: #4a4a4a;
-  line-height: 48px;
-  margin: 10px 0 0 0;
+  line-height: 24px;
+  margin: 24px 0 0 24px;
 }
 
 .writer-detail-sns-account {
-  max-width: 170px;
-  width: 30%;
+  /* max-width: 170px; */
+  width: 20%;
+}
+
+.writer-detail-sns-link {
+  /* max-width: 170px; */
+  width: 50%;
+}
+
+@media (max-width:576px) {
+  .writer-detail-sns-text {
+    margin: 16px 0 0 0;
+  }
+
+  .writer-detail-sns-account {
+    /* max-width: 170px; */
+    width: 75%;
+    margin: 0 auto;
+  }
+
+  .writer-detail-sns-link {
+    /* max-width: 170px; */
+    width: 75%;
+    margin: 0 auto;
+    padding-left: 8%;
+  }
 }
 
 .writer-detail-explain-wrapper {

--- a/src/tufspot/public/css/style_uru.css
+++ b/src/tufspot/public/css/style_uru.css
@@ -543,8 +543,7 @@ input[type="radio"] {
   .writer-detail-sns-link {
     /* max-width: 170px; */
     width: 75%;
-    margin: 0 auto;
-    padding-left: 8%;
+    margin: 5px auto 0 auto;
   }
 }
 

--- a/src/tufspot/resources/views/writer_detail.blade.php
+++ b/src/tufspot/resources/views/writer_detail.blade.php
@@ -24,14 +24,14 @@
                     <p class="writer-detail-title">
                         ▼<span>各種SNS</span>
                     </p>
-                    <div class="writer-detail-sns-wrapper">
+                    <div class="writer-detail-sns-wrapper w-100 m-auto">
                         @foreach ($user->snsAccounts as $snsAccount)
-                            <div class="writer-detail-sns-text d-flex">
+                            <div class="writer-detail-sns-text mx-auto d-block d-sm-flex justify-content-center">
                                 <div class="writer-detail-sns-account">
-                                    {{ $snsAccount['name'] }}
+                                    {{ $snsAccount['name'] }}：
                                 </div>
-                                <div>
-                                    ：<a href="{{ $snsAccount['url'] }}" target="_blank" rel="noopener noreferrer">{{ $snsAccount['url'] }}</a>
+                                <div class="writer-detail-sns-link text-break">
+                                    <a href="{{ $snsAccount['url'] }}" target="_blank" rel="noopener noreferrer">{{ $snsAccount['url'] }}</a>
                                 </div>
                             </div>
                         @endforeach


### PR DESCRIPTION
writer詳細画面 SNS部分 のレスポンシブ崩れを修正対応。

ブレイクポイントは見た目の観点(主観)で　SP - タブレット　間の 576px で設定してますが、
なんかもっといいかんじの案があればご意見ください！