### PR TITLE
【纉】カテゴリー記事一覧のレスポンシブ崩れ

### DIFF
--- a/src/tufspot/public/css/style_uru.css
+++ b/src/tufspot/public/css/style_uru.css
@@ -245,7 +245,7 @@ footer {
   /* filter: drop-shadow(0px 3px 4.5px #d3d3d3); */
   background-color: #f7f7f7;
   /* display: flex; */
-  height: 130px;
+  min-height: 130px;
   /* align-items: center; */
   /* justify-content: center; */
   margin: 0 0 45px 0;

--- a/src/tufspot/public/css/style_uru.css
+++ b/src/tufspot/public/css/style_uru.css
@@ -268,7 +268,7 @@ footer {
   /* height: 100px; */
   align-items: center;
   justify-content: center;
-  padding: 5px 0 0 0;
+  padding: 8px 0 40px 0;
 }
 
 .post_list_title_text {

--- a/src/tufspot/resources/views/components/post_list_title.blade.php
+++ b/src/tufspot/resources/views/components/post_list_title.blade.php
@@ -2,7 +2,7 @@
 
 <div class="post_list_title {{ $class }}">
     <x-bread />
-    <div class="post_list_title_content">
+    <div class="container post_list_title_content">
         <p class="post_list_title_text m-0">{{ $listTitle }}</p>
     </div>
 </div>


### PR DESCRIPTION
https://github.com/Tatsuya-328/tufspot_develop/issues/97

当該ページのトップ、タイトル部がレスポンシブで崩れる問題を修正。
最低限の修正しかやってませんが、マージン調整等のリクエストあれば言ってください！

![スクリーンショット 2023-10-12 220701](https://github.com/Tatsuya-328/tufspot_develop/assets/82076335/852fb06e-c659-4bb8-9850-078235897153)

個人的には、めちゃ長めのタイトル来た時のPC画面を調整すべき？と思っていたり(例えばmain部の余白に合わせるなど)

![スクリーンショット 2023-10-12 221021](https://github.com/Tatsuya-328/tufspot_develop/assets/82076335/d71d5122-c43e-45d0-a7dc-f46fcaaaa6ce)
