### PR TITLE
【纉】writer一覧のレスポンシブ修正

### DIFF
--- a/src/tufspot/public/css/style_uru.css
+++ b/src/tufspot/public/css/style_uru.css
@@ -579,6 +579,10 @@ input[type="radio"] {
     margin: -10px 0 0 10%;
   }
 
+  .writer-explain-wrapper {
+    margin: 0 auto 0;
+  }
+
 }
 
 /* ライター詳細ここまで */


### PR DESCRIPTION
#96 

768px以下で、テキストが右寄りになる問題を修正

<PC>

![スクリーンショット 2023-10-12 224838](https://github.com/Tatsuya-328/tufspot_develop/assets/82076335/9ec1651b-4069-4bbb-ae1c-22b347e9e58f)


<768px以下>

![スクリーンショット 2023-10-12 225047](https://github.com/Tatsuya-328/tufspot_develop/assets/82076335/5aab8721-76b2-49e8-8975-f3aba011d97d)
