### PR TITLE
【纉】検索結果の文字にスタイル

### DIFF
--- a/src/tufspot/public/css/style_uru.css
+++ b/src/tufspot/public/css/style_uru.css
@@ -280,8 +280,9 @@ footer {
 }
 
 .post_list_explain {
-  margin: 0 auto 100px auto;
+  margin: 0 auto 60px auto;
   max-width: 780px;
+  padding: 0 20px;
 }
 
 .feature_box {

--- a/src/tufspot/public/css/style_uru.css
+++ b/src/tufspot/public/css/style_uru.css
@@ -280,7 +280,7 @@ footer {
 }
 
 .post_list_explain {
-  margin: 0 auto 60px auto;
+  margin: 0 auto 80px auto;
   max-width: 780px;
   padding: 0 20px;
 }

--- a/src/tufspot/resources/views/search_result.blade.php
+++ b/src/tufspot/resources/views/search_result.blade.php
@@ -5,15 +5,17 @@
     <x-post_list_title class="unset-shadow" listTitle="検索結果" />
     <x-main>
         {{-- TODO: 検索ワードのスタイリングはいったんカテゴリーからとってきてる、要修正 --}}
-        <div class="post_list_explain d-flex flex-column justify-content-center">
-            <p>
-                検索対象：{{ config('common.search_filter')[$search_filter] }}
+        <div class="post_list_explain d-flex flex-column flex-md-row justify-content-around">
+            <p class="text-center">
+                検索範囲：
+                [{{ config('common.search_filter')[$search_filter] }}]
             </p>
-            @foreach ($keywordArr as $keyword)
-                <p class="post_list_explain_text m-0">
-                    {{ $keyword }}
-                </p>
-            @endforeach
+            <p class="text-center">
+                検索ワード：
+                @foreach ($keywordArr as $keyword)
+                    "{{ $keyword }}"
+                @endforeach
+            </p>
         </div>
         <div class="article-list-area">
             <livewire:paginated-post-list :keywords="$keywordArr" :search_filter="$search_filter" page_flag="search" />

--- a/src/tufspot/resources/views/search_result.blade.php
+++ b/src/tufspot/resources/views/search_result.blade.php
@@ -6,16 +6,14 @@
     <x-main>
         {{-- TODO: 検索ワードのスタイリングはいったんカテゴリーからとってきてる、要修正 --}}
         <div class="post_list_explain d-flex flex-column flex-md-row justify-content-around">
-            <p class="text-center">
-                検索範囲：
-                [{{ config('common.search_filter')[$search_filter] }}]
-            </p>
-            <p class="text-center">
-                検索ワード：
-                @foreach ($keywordArr as $keyword)
-                    "{{ $keyword }}"
-                @endforeach
-            </p>
+            <div class="text-center">
+                <?php
+                // 検索ワードが複数だった場合、謎空白が入らないようにphpのechoで制御
+                foreach ($keywordArr as $keyword) {
+                    echo '「' . $keyword . '」';
+                } ?>
+                を{{ config('common.search_filter')[$search_filter] === '全ての項目' ? '' : config('common.search_filter')[$search_filter] . 'に' }}含む記事
+            </div>
         </div>
         <div class="article-list-area">
             <livewire:paginated-post-list :keywords="$keywordArr" :search_filter="$search_filter" page_flag="search" />


### PR DESCRIPTION
#95 

検索結果画面の検索範囲/ワードのレイアウトを調整
最低限の調整しかできてないので何か改善案あればコメントください！

![スクリーンショット 2023-10-14 173940](https://github.com/Tatsuya-328/tufspot_develop/assets/82076335/1ff67a18-d289-471e-85c2-040758c9add5)

![TUFSPOT_result_20231014_17_40_00](https://github.com/Tatsuya-328/tufspot_develop/assets/82076335/76314cda-74aa-4ff7-b938-83df61eb2fdd)
