### PR TITLE
【纉】記事詳細のユーザー詳細、フォローボタン

### DIFF
--- a/src/tufspot/resources/views/post_detail.blade.php
+++ b/src/tufspot/resources/views/post_detail.blade.php
@@ -75,7 +75,7 @@
             <div class="post-detail-list">
                 {{-- ボーダー用pタグ --}}
                 <p class="post-detail-border writer-last"></p>
-                <div class="post-detail-writer-wrapper d-flex align-items-center flex-wrap">
+                <div class="post-detail-writer-wrapper d-flex align-items-center flex-wrap justify-content-around">
                     @if (Request::method() === 'POST' || Request::method() === 'PUT')
                         <a href="#" class="text-decoration-none">
                             <svg class="d-inline text-secondary" xmlns="http://www.w3.org/2000/svg" width="47" height="47" fill="currentColor" class="bi bi-person-circle" viewBox="0 0 16 16">
@@ -93,7 +93,7 @@
                             <a href="#" class="post-card-button text-center">フォローする</a>
                         </div>
                     @else
-                        <a href="{{ route('writer_detail', ['user' => $post['user']['id']]) }}" class="text-decoration-none">
+                        <a href="{{ route('writer_detail', ['user' => $post['user']['id']]) }}" class="text-decoration-none mb-2">
                             <svg class="d-inline text-secondary" xmlns="http://www.w3.org/2000/svg" width="47" height="47" fill="currentColor" class="bi bi-person-circle" viewBox="0 0 16 16">
                                 <path d="M11 6a3 3 0 1 1-6 0 3 3 0 0 1 6 0z" />
                                 <path fill-rule="evenodd" d="M0 8a8 8 0 1 1 16 0A8 8 0 0 1 0 8zm8-7a7 7 0 0 0-5.468 11.37C3.242 11.226 4.805 10 8 10s4.757 1.225 5.468 2.37A7 7 0 0 0 8 1z" />
@@ -102,8 +102,8 @@
                                 {{ $post['user']['name'] }}
                             </p>
                         </a>
-                        <div class="writer-card-button-wrapper d-flex flex-wrap m-3">
-                            <a href="{{ route('writer_detail', ['user' => $post['user']['id']]) }}" class="post-card-button text-center me-2">プロフィールを見る</a>
+                        <div class="writer-card-button-wrapper d-flex flex-wrap my-3 justify-content-around gap-2">
+                            <a href="{{ route('writer_detail', ['user' => $post['user']['id']]) }}" class="post-card-button text-center mb-2">プロフィールを見る</a>
                             @if (!$post->user->isAuthUser())
                                 <livewire:follow :followed_user="$post->user" />
                             @endif


### PR DESCRIPTION
#108 

記事詳細ページの下部、フォローボタンがレスポンシブで崩れる問題を修正
調整の影響でPC版も変わったけど、要調整の場所あったり前のほうがいいとかあったらコメントください！

![スクリーンショット 2023-10-14 193938](https://github.com/Tatsuya-328/tufspot_develop/assets/82076335/f42ad57b-e0d8-4add-8d15-43aaa8070839)

![スクリーンショット 2023-10-14 193956](https://github.com/Tatsuya-328/tufspot_develop/assets/82076335/6ac7e662-6a65-4e7b-97c5-a634621c64ff)
