### PR TITLE
【纉】プレビューの崩れ直し

### DIFF
--- a/src/tufspot/public/js/modules/postDetail.js
+++ b/src/tufspot/public/js/modules/postDetail.js
@@ -1,7 +1,7 @@
-'use strict';
+"use strict";
 
-if (/\/post\/*/.test(window.location.pathname)) {
+if (/\/(post)|(admin\/preview)\/*/.test(window.location.pathname)) {
     // 実行したいコードをここに書く
-    console.log(document.querySelector('.wrapper'))
-    document.querySelector('.wrapper').classList.add('post-page');
+    console.log(document.querySelector(".wrapper"));
+    document.querySelector(".wrapper").classList.add("post-page");
 }

--- a/src/tufspot/public/js/modules/postDetail.js
+++ b/src/tufspot/public/js/modules/postDetail.js
@@ -1,7 +1,7 @@
-"use strict";
+'use strict';
 
 if (/\/(post)|(admin\/preview)\/*/.test(window.location.pathname)) {
     // 実行したいコードをここに書く
-    console.log(document.querySelector(".wrapper"));
-    document.querySelector(".wrapper").classList.add("post-page");
+    console.log(document.querySelector('.wrapper'));
+    document.querySelector('.wrapper').classList.add('post-page');
 }

--- a/src/tufspot/resources/views/post_detail.blade.php
+++ b/src/tufspot/resources/views/post_detail.blade.php
@@ -77,7 +77,7 @@
                 <p class="post-detail-border writer-last"></p>
                 <div class="post-detail-writer-wrapper d-flex align-items-center flex-wrap justify-content-around">
                     @if (Request::method() === 'POST' || Request::method() === 'PUT')
-                        <a href="#" class="text-decoration-none">
+                        <a href="#" class="text-decoration-none mb-2">
                             <svg class="d-inline text-secondary" xmlns="http://www.w3.org/2000/svg" width="47" height="47" fill="currentColor" class="bi bi-person-circle" viewBox="0 0 16 16">
                                 <path d="M11 6a3 3 0 1 1-6 0 3 3 0 0 1 6 0z" />
                                 <path fill-rule="evenodd" d="M0 8a8 8 0 1 1 16 0A8 8 0 0 1 0 8zm8-7a7 7 0 0 0-5.468 11.37C3.242 11.226 4.805 10 8 10s4.757 1.225 5.468 2.37A7 7 0 0 0 8 1z" />
@@ -86,11 +86,11 @@
                                 Writer Name
                             </p>
                         </a>
-                        <div class="writer-card-button-wrapper">
-                            <a href="#" class="post-card-button text-center me-2">プロフィールを見る</a>
-                        </div>
-                        <div class="writer-card-button-wrapper">
-                            <a href="#" class="post-card-button text-center">フォローする</a>
+                        <div class="writer-card-button-wrapper d-flex flex-wrap my-3 justify-content-around gap-2">
+                            <a href="#" class="post-card-button text-center mb-2">プロフィールを見る</a>
+                            <div class="writer-card-button-wrapper">
+                                <a href="#" class="post-card-button text-center">フォローする</a>
+                            </div>
                         </div>
                     @else
                         <a href="{{ route('writer_detail', ['user' => $post['user']['id']]) }}" class="text-decoration-none mb-2">


### PR DESCRIPTION
#106

記事編集のプレビューレイアウトを実際の記事詳細ページと同様のものに変更

`post-page`クラスを付与するJS(postDetail.js)がプレビューページに対応していなかった模様
`/post/*`だけでなく、無理やり`/admin/preview/*`にヒットするようにしたけど、別ファイルで定義したほうがいいならそうします！