### PR TITLE
【纉】ハッシュタグ重複バグ

### DIFF
--- a/src/tufspot/resources/views/components/writer_explain.blade.php
+++ b/src/tufspot/resources/views/components/writer_explain.blade.php
@@ -14,15 +14,18 @@
             <p class="writer-explain-hashtag">
                 @php
                     $cnt = 0;
+                    $printed_tag = [];
                 @endphp
                 @foreach ($writer['posts'] as $post)
                     @foreach ($post['tags'] as $tag)
                         @if (!empty($tag))
-                            @php
-                                $cnt++;
-                            @endphp
-                            @if ($cnt > 3)
+                            @if ($cnt > 3 or in_array($tag['name'], $printed_tag))
                                 @continue
+                            @else
+                                @php
+                                    $cnt++;
+                                    array_push($printed_tag, $tag['name']);
+                                @endphp
                             @endif
                             <a href="{{ route('hashtag_result', ['tagSlug' => $tag['slug']]) }}" class="text-decoration-none">#{{ $tag['name'] }}</a>
                         @endif


### PR DESCRIPTION
#107

/writerページ、Userが投稿した記事のタグ一覧が重複するバグを修正
blade内で結構ごり押しの記述をしたので、
何か改善案とか制約(ネスト浅くする等)あればコメントください！

![スクリーンショット 2023-10-22 145051](https://github.com/Tatsuya-328/tufspot_develop/assets/82076335/a4e80923-535f-4e54-8215-f3c7ba1aa8e6)
