### PR TITLE
feat: top と writer それぞれの画面でアイコン画像を表示

### DIFF
--- a/src/tufspot/public/css/style_uru.css
+++ b/src/tufspot/public/css/style_uru.css
@@ -1510,7 +1510,7 @@ div>.flickity-prev-next-button.next {
   }
 
   .top_liks {
-    margin
+    /* margin */
   }
 }
 
@@ -1781,7 +1781,7 @@ li.slick-slide>.post_card {
     font-family: "Yu Gothic Medium", "游ゴシック　Medium", Yugothic, "游ゴシック体", "ヒラギノ角ゴ Pro W3", sans-serif;
     line-height: 1.7;
     color: #432;
-    background-color: ;
+    /* background-color: ; */
     background-repeat: no-repeat;
     width: 100%;
   }
@@ -2169,13 +2169,13 @@ aside {
   background-color: #f8f9fa;
 }
 
-*/ @media (max-width:600px) {
+@media (max-width:600px) {
 
   body {
     font-family: "Yu Gothic Medium", "游ゴシック　Medium", Yugothic, "游ゴシック体", "ヒラギノ角ゴ Pro W3", sans-serif;
     line-height: 1.7;
     color: #432;
-    background-color: ;
+    /* background-color: ; */
     background-repeat: no-repeat;
     width: 100%;
     margin-bottom: 100px;

--- a/src/tufspot/public/css/style_uru.css
+++ b/src/tufspot/public/css/style_uru.css
@@ -1096,7 +1096,7 @@ div>.is-selected {
   font-size: 14px;
   line-height: 25px;
   color: #191919;
-  margin: 0 0 28px 0;
+  margin: 0 0 4px 0;
   width: 320px;
 }
 
@@ -1237,7 +1237,7 @@ div>.flickity-button:focus {
   .top-carousel-text {
     font-size: 2vw;
     line-height: 3.5vw;
-    margin: 0 0 0.9vw 0;
+    /* margin: 0 0 0.9vw 0; */
     width: 70vw;
     /* transform: scale(0.9); */
 
@@ -1328,7 +1328,7 @@ div>.flickity-button:focus {
   .top-carousel-text {
     font-size: 9.127px;
     line-height: 16.732px;
-    margin: 0 0 8.46px 0;
+    /* margin: 0 0 8.46px 0; */
     width: 235px;
   }
 
@@ -1346,8 +1346,8 @@ div>.flickity-button:focus {
   }
 
   .top-carousel-hashtag {
-    font-size: 0.94px;
-    margin: 0 0 2.82px 0;
+    /* font-size: .94px; */
+    margin-bottom: 2.82px;
   }
 
   .post-card-writer {
@@ -1381,7 +1381,7 @@ div>.flickity-button:focus {
   .top-carousel-text {
     font-size: 0.971vw;
     line-height: 1.78vw;
-    margin: 0 0 0.9vw 0;
+    /* margin: 0 0 0.9vw 0; */
     width: 25vw;
   }
 
@@ -1399,8 +1399,8 @@ div>.flickity-button:focus {
   }
 
   .top-carousel-hashtag {
-    font-size: 0.1vw;
-    margin: 0 0 0.3vw 0;
+    /* font-size: .1vw; */
+    margin-bottom: .5vw;
   }
 
   .post-card-writer {
@@ -1436,7 +1436,7 @@ div>.flickity-button:focus {
     font-size: 14px;
     line-height: 25px;
     color: #191919;
-    margin: 0 0 28px 0;
+    /* margin: 0 0 28px 0; */
     width: 320px;
   }
 

--- a/src/tufspot/public/css/style_uru.css
+++ b/src/tufspot/public/css/style_uru.css
@@ -1111,6 +1111,16 @@ div>.is-selected {
   color: inherit;
 }
 
+.post-card-writer-wrapper>a {
+  align-items: center;
+  display: flex;
+}
+
+.post-card-writer-wrapper>a>img {
+  height: 26px;
+  width: 26px;
+}
+
 .top-carousel-image-wrapper {
   /* margin: auto 50px auto 0px; */
 }

--- a/src/tufspot/resources/views/components/post_card.blade.php
+++ b/src/tufspot/resources/views/components/post_card.blade.php
@@ -26,12 +26,16 @@
                 <a href="{{ route('hashtag_result', ['tagSlug' => $post['id']]) }}" class="text-decoration-none">#ハッシュタグ</a> --}}
             </span>
         </p>
-        <div>
+        <div class="post-card-writer-wrapper">
             <a href="{{ route('writer_detail', ['user' => $post['user']['id']]) }}" class="text-decoration-none">
-                <svg class="d-inline text-secondary" xmlns="http://www.w3.org/2000/svg" width="26" height="26" fill="currentColor" class="bi bi-person-circle" viewBox="0 0 16 16">
-                    <path d="M11 6a3 3 0 1 1-6 0 3 3 0 0 1 6 0z" />
-                    <path fill-rule="evenodd" d="M0 8a8 8 0 1 1 16 0A8 8 0 0 1 0 8zm8-7a7 7 0 0 0-5.468 11.37C3.242 11.226 4.805 10 8 10s4.757 1.225 5.468 2.37A7 7 0 0 0 8 1z" />
-                </svg>
+                @if ($post['user']['profile_image_path'])
+                    <img loading="lazy" src="{{ $post['user']['profile_image_path'] }}" class="" alt="{{ $post['user']['name'] }} のプロフィール画像" />
+                @else
+                    <svg class="d-inline text-secondary" xmlns="http://www.w3.org/2000/svg" width="26" height="26" fill="currentColor" class="bi bi-person-circle" viewBox="0 0 16 16">
+                        <path d="M11 6a3 3 0 1 1-6 0 3 3 0 0 1 6 0z" />
+                        <path fill-rule="evenodd" d="M0 8a8 8 0 1 1 16 0A8 8 0 0 1 0 8zm8-7a7 7 0 0 0-5.468 11.37C3.242 11.226 4.805 10 8 10s4.757 1.225 5.468 2.37A7 7 0 0 0 8 1z" />
+                    </svg>
+                @endif
                 <p class="post-card-writer">
                     {{-- Writer Name --}}
                     {{ $post['user']['name'] }}

--- a/src/tufspot/resources/views/components/post_card_carousel.blade.php
+++ b/src/tufspot/resources/views/components/post_card_carousel.blade.php
@@ -36,10 +36,14 @@
             </p>
             <div class="post-card-writer-wrapper">
                 <a href="{{ route('writer_detail', ['user' => $post['user']['id']]) }}" class="text-decoration-none">
-                    <svg class="d-inline text-secondary" xmlns="http://www.w3.org/2000/svg" width="26" height="26" fill="currentColor" class="bi bi-person-circle" viewBox="0 0 16 16">
-                        <path d="M11 6a3 3 0 1 1-6 0 3 3 0 0 1 6 0z" />
-                        <path fill-rule="evenodd" d="M0 8a8 8 0 1 1 16 0A8 8 0 0 1 0 8zm8-7a7 7 0 0 0-5.468 11.37C3.242 11.226 4.805 10 8 10s4.757 1.225 5.468 2.37A7 7 0 0 0 8 1z" />
-                    </svg>
+                    @if ($post['user']['profile_image_path'])
+                        <img loading="lazy" src="{{ $post['user']['profile_image_path'] }}" class="" alt="{{ $post['user']['name'] }} のプロフィール画像" />
+                    @else
+                        <svg class="d-inline text-secondary" xmlns="http://www.w3.org/2000/svg" width="26" height="26" fill="currentColor" class="bi bi-person-circle" viewBox="0 0 16 16">
+                            <path d="M11 6a3 3 0 1 1-6 0 3 3 0 0 1 6 0z" />
+                            <path fill-rule="evenodd" d="M0 8a8 8 0 1 1 16 0A8 8 0 0 1 0 8zm8-7a7 7 0 0 0-5.468 11.37C3.242 11.226 4.805 10 8 10s4.757 1.225 5.468 2.37A7 7 0 0 0 8 1z" />
+                        </svg>
+                    @endif
                     <p class="post-card-writer">
                         {{-- Writer Name --}}
                         {{ $post['user']['name'] }}

--- a/src/tufspot/resources/views/components/writer_card.blade.php
+++ b/src/tufspot/resources/views/components/writer_card.blade.php
@@ -1,8 +1,7 @@
 <div class="writer-card d-flex flex-wrap flex-column align-content-center" wire:key="writer-{{ $writer->id }}">
     <a href="{{ route('writer_detail', ['user' => $writer['id']]) }}" class="text-decoration-none">
         <div class="d-flex flex-wrap flex-column justify-content-center align-content-center">
-            {{-- TODO: アイコン画像表示 --}}
-            <img loading="lazy" src="{{ asset('image/fox_circle.png') }}" style="width:100px; height:100px;" class="" alt="...">
+            <img loading="lazy" src="{{ $writer['profile_image_path'] ?? asset('image/fox_circle.png') }}" style="width: 26px; height: 26px;" class="" alt="{{ $writer['name'] }} のプロフィール画像" />
         </div>
         <p class="writer-card-name text-center">
             {{ $writer['name'] }}

--- a/src/tufspot/resources/views/components/writer_card.blade.php
+++ b/src/tufspot/resources/views/components/writer_card.blade.php
@@ -1,7 +1,14 @@
 <div class="writer-card d-flex flex-wrap flex-column align-content-center" wire:key="writer-{{ $writer->id }}">
     <a href="{{ route('writer_detail', ['user' => $writer['id']]) }}" class="text-decoration-none">
         <div class="d-flex flex-wrap flex-column justify-content-center align-content-center">
-            <img loading="lazy" src="{{ $writer['profile_image_path'] ?? asset('image/fox_circle.png') }}" style="width: 26px; height: 26px;" class="" alt="{{ $writer['name'] }} のプロフィール画像" />
+            @if ($writer['profile_image_path'])
+                <img loading="lazy" src="{{ $writer['profile_image_path'] }}" class="" alt="{{ $writer['name'] }} のプロフィール画像" style="height: 100px; width: 100px;" />
+            @else
+                <svg class="d-inline text-secondary" xmlns="http://www.w3.org/2000/svg" width="100" height="100" fill="currentColor" class="bi bi-person-circle" viewBox="0 0 16 16">
+                    <path d="M11 6a3 3 0 1 1-6 0 3 3 0 0 1 6 0z" />
+                    <path fill-rule="evenodd" d="M0 8a8 8 0 1 1 16 0A8 8 0 0 1 0 8zm8-7a7 7 0 0 0-5.468 11.37C3.242 11.226 4.805 10 8 10s4.757 1.225 5.468 2.37A7 7 0 0 0 8 1z" />
+                </svg>
+            @endif
         </div>
         <p class="writer-card-name text-center">
             {{ $writer['name'] }}


### PR DESCRIPTION
resolve #119 

## バックエンド
- 今回の実装では特に触っていません

## フロント（JavaScript）
- 今回の実装では特に触っていません

## フロント（CSS）
- top ページでハッシュタグが `font-size` と `margin` の設定ミスで見えなくなっていたので併せて修正しています
- コメントアウトのミスで構文エラーになっていた箇所を併せて修正しています

## 備考
- ユーザのアイコン画像が未登録の場合、top ページでは SVG、writer ページではキツネのイラスト画像を表示するようにしています
  - 実際の運用では、ユーザによる画像の登録がなかった場合はプレースホルダー的な画像パスを `users` の `profile_image_path` に決め打ちで保存するだけでもいいかもしれません