### PR TITLE
Adminのユーザー編集のSNS欄、表示バグ

### DIFF
--- a/src/tufspot/public/css/admin.css
+++ b/src/tufspot/public/css/admin.css
@@ -127,7 +127,7 @@
 }
 
 .bt_deleteForm {
-  width: 10px;
+  /* width: 10px; */
 }
 
 /* users.edit */

--- a/src/tufspot/resources/views/back/users/_form.blade.php
+++ b/src/tufspot/resources/views/back/users/_form.blade.php
@@ -76,11 +76,11 @@
     function addForm(Cnt) {
         var Cnt = Cnt + 1;
         let textbox_element = document.getElementById('form-group');
-        const createElement = '<div class="col-sm-3 mt-1" id="form_area' + Cnt +
+        const createElement = '<div class="col-sm-3 mb-1" id="form_area' + Cnt +
             '"><input type="text" class="form-control " name="newSnsAccounts[' + Cnt +
-            '][name]" value="" placeholder="Instagram" /> </div> <div class = "col-sm-7 mt-1"id = "form_area' + Cnt +
-            '" ><input type = "text"class = "form-control "name = "newSnsAccounts[' + Cnt +
-            '][url]"value = "" placeholder="https://www.instagram.com" / ></div>    <div class="bt_deleteForm col-sm-2">   <input type="button" value="削除" class="formRemove btn btn-outline-dark"  onclick="removeForm(this)" ></div>';
+            '][name]" value="" placeholder="Instagram" /> </div> <div class = "col-sm-8 mb-1"id = "form_area' + Cnt +
+            '" ><input type = "text"class = "form-control"name = "newSnsAccounts[' + Cnt +
+            '][url]"value = "" placeholder="https://www.instagram.com" / ></div> <div class="bt_deleteForm col-sm-1 mb-2 mb-sm-1 "><input type="button" value="削除" class="formRemove btn btn-outline-dark"  onclick="removeForm(this)" ></div>';
         // 指定した要素の中の末尾に挿入
         textbox_element.insertAdjacentHTML('beforeend', createElement);
     }
@@ -205,58 +205,52 @@
     </div>
 </div>
 
-@if (!empty($user['snsAccounts'][0]))
 
-    <div class="mb-4 row">
-        <label for="input" class="col-sm-2 col-form-label">SNS</label>
-        <div id="form-group" class="w-100">
-            <div class="d-flex ms-1">
+<div class="mb-2 row">
+    <label for="input" class="col-sm-2 col-form-label">SNS</label>
+    {{-- <div id="form-group" class="col post-form-col"> --}}
+    <div class="col">
+        <div class="row" id="form-group" style="margin-right: -9px">
+            @if (!empty($user['snsAccounts'][0]))
                 @foreach ($user['snsAccounts'] as $snsAccount)
                     <input type="hidden" name="alreadySnsAccounts[{{ $loop->iteration }}]['id']" value="{{ $snsAccount['id'] }}" />
-                    <div class="me-2" id="form_area{{ $loop->iteration }}">
+                    <div class="col-sm-3 mb-1" id="form_area{{ $loop->iteration }}">
                         <input type="text" class="form-control" name="alreadySnsAccounts[{{ $loop->iteration }}][name]" value="{{ $snsAccount['name'] }}" />
                     </div>
-                    <div class="me-2" id="form_area{{ $loop->iteration }}">
+                    <div class="col-sm-8 mb-1" id="form_area{{ $loop->iteration }}">
                         <input type="text" class="form-control" name="alreadySnsAccounts[{{ $loop->iteration }}][url]" value="{{ $snsAccount['url'] }}" />
                     </div>
-                    <div class="bt_deleteForm col-sm-2">
+                    <div class="col-sm-1 mb-2 mb-sm-1 bt_deleteForm">
                         <input type="button" value="削除" class="formRemove btn btn-outline-dark" onclick="removeForm(this)">
                     </div>
                     @php
                         $cnt = $loop->iteration;
                     @endphp
                 @endforeach
-            </div>
-        </div>
-        <input type="button" class="btn btn-outline-dark h-25 align-self-end" value="追加" onclick="addForm({{ $cnt }})" />
-    </div>
-@else
-    <div class="mb-2 row">
-        <label for="input" class="col-sm-2 col-form-label">SNS</label>
-        {{-- <div id="form-group" class="col post-form-col"> --}}
-        <div class="col row" id="form-group">
-            <div class="col-sm-3" id="form_area1">
-                <input type="text" class="form-control" name="newSnsAccounts[1][name]" value="" placeholder="Instagram" />
-            </div>
-            <div class="col-sm-7" id="form_area2">
-                <input type="text" class="form-control" name="newSnsAccounts[1][url]" value="" placeholder="https://www.instagram.com" />
-            </div>
-            <div class="bt_deleteForm">
-                <input type="button" value="削除" class="formRemove btn btn-outline-dark" onclick="removeForm(this)">
-            </div>
+            @else
+                <div class="col-sm-3 mb-1" id="form_area1">
+                    <input type="text" class="form-control" name="newSnsAccounts[1][name]" value="" placeholder="Instagram" />
+                </div>
+                <div class="col-sm-8 mb-1" id="form_area2">
+                    <input type="text" class="form-control" name="newSnsAccounts[1][url]" value="" placeholder="https://www.instagram.com" />
+                </div>
+                <div class="col-sm-1 mb-2 mb-sm-1 bt_deleteForm">
+                    <input type="button" value="削除" class="formRemove btn btn-outline-dark" onclick="removeForm(this)">
+                </div>
+            @endif
             {{-- <div class="bt_deleteForm">
                 <input type="button" class="btn btn-outline-dark align-self-end" value="追加" onclick="addForm(1)" />
             </div> --}}
         </div>
-        {{-- </div> --}}
-        {{-- <div class="col-sm-1"> --}}
-    </div>
-    <div class="d-flex justify-content-end mb-4">
-        <input type="button" class="btn btn-outline-dark" value="追加" onclick="addForm(1)" />
     </div>
     {{-- </div> --}}
+    {{-- <div class="col-sm-1"> --}}
+</div>
+<div class="d-flex justify-content-end mb-4">
+    <input type="button" class="btn btn-outline-dark" value="追加" onclick="addForm(1)" />
+</div>
+{{-- </div> --}}
 
-@endif
 
 
 <div class="d-flex justify-content-between mt-4 mb-4">


### PR DESCRIPTION
#124

Adminページ/ユーザー編集のSNS欄で、レイアウトが崩れる問題を修正。

こっちで勝手にレイアウト調整したけど想定してた感じになってるかな？
ご意見ください！

[修正後]

![スクリーンショット 2023-10-28 171058](https://github.com/Tatsuya-328/tufspot_develop/assets/82076335/12c1167e-d591-498f-8afd-6b4ab0071c65)

[入力欄の追加]

![スクリーンショット 2023-10-28 171110](https://github.com/Tatsuya-328/tufspot_develop/assets/82076335/a8eaae85-d374-4883-8807-4749d73dd764)

[レスポンシブ]

![スクリーンショット 2023-10-28 171334](https://github.com/Tatsuya-328/tufspot_develop/assets/82076335/402f4003-16c0-4d0e-8679-f9270ec2d518)


一応ローカル環境でSNSアカウントの追加/削除の動作チェックも済み。