### PR TITLE
feat: ユーザーIDと記事IDをURL上にて固有IDにする

### DIFF
--- a/src/tufspot/app/Http/Controllers/Auth/RegisterController.php
+++ b/src/tufspot/app/Http/Controllers/Auth/RegisterController.php
@@ -88,14 +88,19 @@ class RegisterController extends Controller
             return Validator::make($data, $rulus, $message);
         }
 
+        $messages = [
+            'tufspot_id.regex' => 'TUFSPOT IDには、半角英数字およびアンダースコアのみを指定してください。',
+        ];
+
         return Validator::make($data, [
             // 会員IDと電話番号が存在するか確認
             'id' => ['required', 'string', 'exists:gaigokai_members,id'],
             'phone_number' => ['required', 'string', 'exists:gaigokai_members,phone_number'],
             'name' => ['required', 'string', 'max:255'],
+            'tufspot_id' => ['required', 'string', 'regex:/^[a-z0-9\_]{3,16}$/i'],
             'email' => ['required', 'string', 'email', 'max:255', 'unique:users'],
             'password' => ['required', 'string', 'min:8', 'confirmed'],
-        ]);
+        ], $messages);
     }
 
     /**
@@ -109,6 +114,7 @@ class RegisterController extends Controller
         // アプリのユーザー登録
         $user = User::create([
             'name' => $data['name'],
+            'tufspot_id' => $data['tufspot_id'],
             'email' => $data['email'],
             'password' => Hash::make($data['password']),
             // 'password' => bcrypt($data['password']),

--- a/src/tufspot/app/Http/Controllers/Back/PostController.php
+++ b/src/tufspot/app/Http/Controllers/Back/PostController.php
@@ -135,10 +135,10 @@ class PostController extends Controller
     /**
      * プレビュー画面
      *
-     * @param int $id
+     * @param string $id
      * @return \Illuminate\Contracts\View\View
      */
-    public function preview(int $id = null, PostUpdateRequest $request)
+    public function preview(string $id = null, PostUpdateRequest $request)
     {
         $post = $request;
 

--- a/src/tufspot/app/Http/Controllers/PostController.php
+++ b/src/tufspot/app/Http/Controllers/PostController.php
@@ -99,10 +99,10 @@ class PostController extends Controller
     /**
      * 詳細画面
      *
-     * @param int $id
+     * @param string $id
      * @return \Illuminate\Contracts\View\View
      */
-    public function show(int $id)
+    public function show(string $id)
     {
         $user = Auth::user();
         $post = Post::publicFindById($id);
@@ -125,7 +125,7 @@ class PostController extends Controller
     /**
      * カテゴリー・特集項目一覧
      *
-     * @param int $id
+     * @param string $id
      * @return \Illuminate\Contracts\View\View
      */
     public function category()
@@ -138,7 +138,7 @@ class PostController extends Controller
     /**
      * カテゴリー・特集の対象記事一覧
      *
-     * @param int $id
+     * @param string $id
      * @return \Illuminate\Contracts\View\View
      */
     public function category_detail($type, $slug)

--- a/src/tufspot/app/Http/Controllers/UserController.php
+++ b/src/tufspot/app/Http/Controllers/UserController.php
@@ -9,6 +9,7 @@ use App\Models\GaigokaiMember;
 use Illuminate\Support\Facades\Auth;
 use App\Models\SnsAccount;
 use App\Http\Requests\UserRequest;
+use Exception;
 
 class UserController extends Controller
 {
@@ -22,22 +23,24 @@ class UserController extends Controller
      * @param User $user
      * @return \Illuminate\Contracts\View\View
      */
-    public function show(User $user)
+    public function show(string $user)
     {
-        // 管理者かつ記事を持っている(公開済み)ユーザーのみ表示（ユーザー一覧でもやる）
-        $user = User::with('posts')->where([
-            ['id', '=', $user['id']],
-            ['role', '=', 1],
-        ])->whereHas('posts', function ($q) {
-            $q->whereExists(function ($q) {
-                return $q;
-            });
-        })->first();
-        if (empty($user)) {
+        try {
+            // 管理者ユーザーの場合は取得（ユーザー一覧でもやる）
+            $user = User::with('posts')->where([
+                ['name', '=', "$user"],
+                ['role', '=', 1],
+            ])->firstOrFail();
+
+            // 公開済み記事数が 0 の場合も 404 を返す
+            if ($user->posts->count() === 0) {
+                throw new Exception();
+            }
+
+            return view('writer_detail', compact('user'));
+        } catch (Exception) {
             abort(404, '存在しないページです');
         }
-
-        return view('writer_detail', compact('user'));
     }
 
     /**

--- a/src/tufspot/app/Http/Controllers/UserController.php
+++ b/src/tufspot/app/Http/Controllers/UserController.php
@@ -28,7 +28,7 @@ class UserController extends Controller
         try {
             // 管理者ユーザーの場合は取得（ユーザー一覧でもやる）
             $user = User::with('posts')->where([
-                ['name', '=', "$user"],
+                ['tufspot_id', '=', "$user"],
                 ['role', '=', 1],
             ])->firstOrFail();
 

--- a/src/tufspot/app/Http/Requests/UserRequest.php
+++ b/src/tufspot/app/Http/Requests/UserRequest.php
@@ -43,6 +43,7 @@ class UserRequest extends FormRequest
         $validate = [
             // 'name' => ['required', 'string', 'max:255', Rule::unique('users')->ignore($this->user)],
             'name' => ['required', 'string', 'max:255'],
+            'tufspot_id' => ['required', 'string', 'regex:/^[a-z0-9\_]{3,16}$/i'],
             'email' => 'required|string|email|max:255',
             'password' => 'required|string',
             'password_check' => 'required|string',
@@ -56,5 +57,17 @@ class UserRequest extends FormRequest
         }
 
         return $validate;
+    }
+
+    /**
+     * 定義済みバリデーションルールのエラーメッセージ取得
+     *
+     * @return array<string, string>
+     */
+    public function messages(): array
+    {
+        return [
+            'tufspot_id.regex' => 'TUFSPOT IDには、半角英数字およびアンダースコアのみを指定してください。',
+        ];
     }
 }

--- a/src/tufspot/app/Models/Post.php
+++ b/src/tufspot/app/Models/Post.php
@@ -2,6 +2,7 @@
 
 namespace App\Models;
 
+use Illuminate\Database\Eloquent\Concerns\HasUlids;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Builder;
@@ -10,7 +11,7 @@ use Illuminate\Support\Facades\Auth;
 
 class Post extends Model
 {
-    use HasFactory;
+    use HasFactory, HasUlids;
 
     protected $fillable = [
         'title', 'body', 'description', 'is_public', 'published_at', 'featured_image_path', 'user_id', 'update_user_id'
@@ -160,10 +161,10 @@ class Post extends Model
      * 公開記事をIDで取得
      *
      * @param Builder $query
-     * @param int $id
+     * @param string $id
      * @return Builder
      */
-    public function scopePublicFindById(Builder $query, int $id)
+    public function scopePublicFindById(Builder $query, string $id)
     {
         return $query->public()->findOrFail($id);
     }
@@ -172,10 +173,10 @@ class Post extends Model
      * 全記事をIDで取得
      *
      * @param Builder $query
-     * @param int $id
+     * @param string $id
      * @return Builder
      */
-    public function scopeFindById(Builder $query, int $id)
+    public function scopeFindById(Builder $query, string $id)
     {
         return $query->findOrFail($id);
     }

--- a/src/tufspot/app/Models/User.php
+++ b/src/tufspot/app/Models/User.php
@@ -30,6 +30,7 @@ class User extends Authenticatable
     protected $fillable = [
         'id',
         'name',
+        'tufspot_id',
         'email',
         'password',
         'role',

--- a/src/tufspot/database/migrations/2014_10_12_000000_create_users_table.php
+++ b/src/tufspot/database/migrations/2014_10_12_000000_create_users_table.php
@@ -16,6 +16,7 @@ class CreateUsersTable extends Migration
         Schema::create('users', function (Blueprint $table) {
             $table->id();
             // $table->foreignId('id');
+            $table->string('tufspot_id')->unique();
             $table->string('name');
             $table->string('email')->unique();
             $table->timestamp('email_verified_at')->nullable();

--- a/src/tufspot/database/migrations/2020_11_02_222724_create_posts_table.php
+++ b/src/tufspot/database/migrations/2020_11_02_222724_create_posts_table.php
@@ -14,7 +14,7 @@ class CreatePostsTable extends Migration
     public function up()
     {
         Schema::create('posts', function (Blueprint $table) {
-            $table->id();
+            $table->uuid('id')->primary();
             $table->string('title');
             $table->string('description');
             $table->string('featured_image_path')->nullable();

--- a/src/tufspot/database/migrations/2020_11_14_171435_create_features_table.php
+++ b/src/tufspot/database/migrations/2020_11_14_171435_create_features_table.php
@@ -24,7 +24,8 @@ class CreateFeaturesTable extends Migration
 
         Schema::create('feature_post', function (Blueprint $table) {
             $table->increments('id');
-            $table->foreignId('post_id')->constrained()->onDelete('cascade');
+            $table->uuid('post_id');
+            $table->foreign('post_id')->references('id')->on('posts')->onDelete('cascade');
             $table->foreignId('feature_id')->constrained()->onDelete('cascade');
         });
     }

--- a/src/tufspot/database/migrations/2020_11_15_171547_create_categories_table.php
+++ b/src/tufspot/database/migrations/2020_11_15_171547_create_categories_table.php
@@ -24,7 +24,8 @@ class CreateCategoriesTable extends Migration
 
         Schema::create('category_post', function (Blueprint $table) {
             $table->increments('id');
-            $table->foreignId('post_id')->constrained()->onDelete('cascade');
+            $table->uuid('post_id');
+            $table->foreign('post_id')->references('id')->on('posts')->onDelete('cascade');
             $table->foreignId('category_id')->constrained()->onDelete('cascade');
         });
     }

--- a/src/tufspot/database/migrations/2020_11_15_171548_create_tags_table.php
+++ b/src/tufspot/database/migrations/2020_11_15_171548_create_tags_table.php
@@ -22,7 +22,8 @@ class CreateTagsTable extends Migration
 
         Schema::create('post_tag', function (Blueprint $table) {
             $table->increments('id');
-            $table->foreignId('post_id')->constrained()->onDelete('cascade');
+            $table->uuid('post_id');
+            $table->foreign('post_id')->references('id')->on('posts')->onDelete('cascade');
             $table->foreignId('tag_id')->constrained()->onDelete('cascade');
         });
     }

--- a/src/tufspot/database/migrations/2023_09_23_025355_create_likes_table.php
+++ b/src/tufspot/database/migrations/2023_09_23_025355_create_likes_table.php
@@ -14,7 +14,8 @@ return new class extends Migration
         Schema::create('likes', function (Blueprint $table) {
             $table->id();
             $table->foreignId('user_id')->constrained()->cascadeOnDelete();
-            $table->foreignId('post_id')->constrained()->cascadeOnDelete();
+            $table->uuid('post_id');
+            $table->foreign('post_id')->references('id')->on('posts')->onDelete('cascade');
             $table->timestamps();
         });
     }

--- a/src/tufspot/database/migrations/2023_10_07_200915_create_reservation_posts_table.php
+++ b/src/tufspot/database/migrations/2023_10_07_200915_create_reservation_posts_table.php
@@ -14,7 +14,8 @@ return new class extends Migration
         Schema::create('reservation_posts', function (Blueprint $table) {
             $table->id();
             $table->foreignId('user_id')->constrained();
-            $table->foreignId('post_id')->constrained();
+            $table->uuid('post_id');
+            $table->foreign('post_id')->references('id')->on('posts');
             $table->string('date', 16);
             $table->string('time', 16);
             $table->timestamps();

--- a/src/tufspot/database/seeds/CategorySeeder.php
+++ b/src/tufspot/database/seeds/CategorySeeder.php
@@ -2,6 +2,7 @@
 
 namespace Database\Seeds;
 
+use App\Models\Post;
 use Illuminate\Database\Seeder;
 use Faker\Factory as Faker;
 
@@ -40,9 +41,9 @@ class CategorySeeder extends Seeder
             ]
         ]);
 
-        for ($i = 1; $i <= 100; $i++) {
+        foreach (Post::take(100)->get() as $post) {
             \DB::table('category_post')->insert([
-                'post_id' => $i,
+                'post_id' => $post->id,
                 'category_id' => $faker->numberBetween(1, 3)
             ]);
         }

--- a/src/tufspot/database/seeds/FeatureSeeder.php
+++ b/src/tufspot/database/seeds/FeatureSeeder.php
@@ -2,6 +2,7 @@
 
 namespace Database\Seeds;
 
+use App\Models\Post;
 use Illuminate\Database\Seeder;
 use Faker\Factory as Faker;
 
@@ -48,9 +49,9 @@ class FeatureSeeder extends Seeder
             ]
         ]);
 
-        for ($i = 1; $i <= 100; $i++) {
+        foreach (Post::take(100)->get() as $post) {
             \DB::table('feature_post')->insert([
-                'post_id' => $i,
+                'post_id' => $post->id,
                 'feature_id' => $faker->numberBetween(1, 4)
             ]);
         }

--- a/src/tufspot/database/seeds/PostSeeder.php
+++ b/src/tufspot/database/seeds/PostSeeder.php
@@ -4,6 +4,7 @@ namespace Database\Seeds;
 
 use Illuminate\Database\Seeder;
 use App\Models\Post;
+use App\Models\User;
 
 class PostSeeder extends Seeder
 {
@@ -18,27 +19,9 @@ class PostSeeder extends Seeder
             Post::factory()->count(100)->create();
         });
 
-        \DB::table('likes')->insert([
-            [
-                'user_id' => 2,
-                'post_id' => 1,
-            ],
-            [
-                'user_id' => 2,
-                'post_id' => 2,
-            ],
-            [
-                'user_id' => 2,
-                'post_id' => 3,
-            ],
-            [
-                'user_id' => 2,
-                'post_id' => 4,
-            ],
-            [
-                'user_id' => 2,
-                'post_id' => 5,
-            ],
-        ]);
+        $seedingUser = User::find(2);
+        foreach (Post::take(5)->get() as $post) {
+            $seedingUser->likes()->attach($post->id);
+        }
     }
 }

--- a/src/tufspot/database/seeds/TagSeeder.php
+++ b/src/tufspot/database/seeds/TagSeeder.php
@@ -2,6 +2,7 @@
 
 namespace Database\Seeds;
 
+use App\Models\Post;
 use Illuminate\Database\Seeder;
 use Faker\Factory as Faker;
 
@@ -20,12 +21,12 @@ class TagSeeder extends Seeder
                 'slug' => 'news',
                 'created_at' => now(),
                 'updated_at' => now()
-            ],[
+            ], [
                 'name' => 'リリース',
                 'slug' => 'release',
                 'created_at' => now(),
                 'updated_at' => now()
-            ],[
+            ], [
                 'name' => 'キャンペーン',
                 'slug' => 'campaign',
                 'created_at' => now(),
@@ -33,11 +34,10 @@ class TagSeeder extends Seeder
             ]
         ]);
 
-        $faker = Faker::create();
-        for ($i = 1; $i <= 50; $i++) {
+        foreach (Post::take(100)->get() as $post) {
             \DB::table('post_tag')->insert([
-                'post_id' => $i,
-                'tag_id' => $faker->numberBetween(1,3)
+                'post_id' => $post->id,
+                'tag_id' => fake()->numberBetween(1, 3)
             ]);
         }
     }

--- a/src/tufspot/database/seeds/UserSeeder.php
+++ b/src/tufspot/database/seeds/UserSeeder.php
@@ -18,6 +18,7 @@ class UserSeeder extends Seeder
         \DB::table('users')->insert([
             [
                 'name' => 'スーパーユーザー',
+                'tufspot_id' => 'super_user',
                 'email' => 'admin@example.com',
                 'email_verified_at' => now(),
                 'password' => \Hash::make('admin'),
@@ -28,6 +29,7 @@ class UserSeeder extends Seeder
             ],
             [
                 'name' => '管理者テスト',
+                'tufspot_id' => 'admin_test',
                 'email' => 'test@example.com',
                 'email_verified_at' => now(),
                 'password' => \Hash::make('testtest'),
@@ -38,6 +40,7 @@ class UserSeeder extends Seeder
             ],
             [
                 'name' => '管理者太郎',
+                'tufspot_id' => 'admin_taro',
                 'email' => 'taro@example.com',
                 'email_verified_at' => now(),
                 'password' => \Hash::make('testtest'),
@@ -48,6 +51,7 @@ class UserSeeder extends Seeder
             ],
             [
                 'name' => '執筆テスト',
+                'tufspot_id' => 'editor_test',
                 'email' => 'writer@example.com',
                 'email_verified_at' => now(),
                 'password' => \Hash::make('testtest'),
@@ -58,6 +62,7 @@ class UserSeeder extends Seeder
             ],
             [
                 'name' => 'テスト用1',
+                'tufspot_id' => 'test_1',
                 'email' => 'test1@example.com',
                 'email_verified_at' => now(),
                 'password' => \Hash::make('testtest'),
@@ -68,6 +73,7 @@ class UserSeeder extends Seeder
             ],
             [
                 'name' => 'テスト用2',
+                'tufspot_id' => 'test_2',
                 'email' => 'test2@example.com',
                 'email_verified_at' => now(),
                 'password' => \Hash::make('testtest'),
@@ -78,6 +84,7 @@ class UserSeeder extends Seeder
             ],
             [
                 'name' => 'テスト用3',
+                'tufspot_id' => 'test_3',
                 'email' => 'test3@example.com',
                 'email_verified_at' => now(),
                 'password' => \Hash::make('testtest'),
@@ -88,6 +95,7 @@ class UserSeeder extends Seeder
             ],
             [
                 'name' => 'テスト用4',
+                'tufspot_id' => 'test_4',
                 'email' => 'test4@example.com',
                 'email_verified_at' => now(),
                 'password' => \Hash::make('testtest'),
@@ -98,6 +106,7 @@ class UserSeeder extends Seeder
             ],
             [
                 'name' => 'テスト用5',
+                'tufspot_id' => 'test_5',
                 'email' => 'test5@example.com',
                 'email_verified_at' => now(),
                 'password' => \Hash::make('testtest'),
@@ -108,6 +117,7 @@ class UserSeeder extends Seeder
             ],
             [
                 'name' => 'テスト用6',
+                'tufspot_id' => 'test_6',
                 'email' => 'test6@example.com',
                 'email_verified_at' => now(),
                 'password' => \Hash::make('testtest'),
@@ -118,6 +128,7 @@ class UserSeeder extends Seeder
             ],
             [
                 'name' => 'テスト用7',
+                'tufspot_id' => 'test_7',
                 'email' => 'test7@example.com',
                 'email_verified_at' => now(),
                 'password' => \Hash::make('testtest'),
@@ -128,6 +139,7 @@ class UserSeeder extends Seeder
             ],
             [
                 'name' => 'テスト用8',
+                'tufspot_id' => 'test_8',
                 'email' => 'test8@example.com',
                 'email_verified_at' => now(),
                 'password' => \Hash::make('testtest'),
@@ -138,6 +150,7 @@ class UserSeeder extends Seeder
             ],
             [
                 'name' => '読者テスト',
+                'tufspot_id' => 'reader_test',
                 'email' => 'reader@example.com',
                 'email_verified_at' => now(),
                 'password' => \Hash::make('testtest'),
@@ -148,6 +161,7 @@ class UserSeeder extends Seeder
             ],
             [
                 'name' => '読者花子',
+                'tufspot_id' => 'reader_hanako',
                 'email' => 'hanako@example.com',
                 'email_verified_at' => now(),
                 'password' => \Hash::make('testtest'),

--- a/src/tufspot/resources/lang/ja/validation.php
+++ b/src/tufspot/resources/lang/ja/validation.php
@@ -140,6 +140,7 @@ return [
         'id' => '外語会ID',
         'phone number' => '電話番号',
         'phone_number' => '電話番号',
+        'tufspot_id' => 'TUFSPOT ID',
     ],
 
     /*
@@ -153,4 +154,3 @@ return [
     |
     */
 ];
-

--- a/src/tufspot/resources/views/auth/register.blade.php
+++ b/src/tufspot/resources/views/auth/register.blade.php
@@ -49,6 +49,18 @@
 
                             <div class="row mb-3">
                                 <div class="col-md-6">
+                                    <input id="tufspot_id" type="text" class="form-control @error('tufspot_id') is-invalid @enderror" name="tufspot_id" value="{{ old('tufspot_id') }}" required autocomplete="off" placeholder="TUFSPOT ID">
+
+                                    @error('tufspot_id')
+                                        <span class="invalid-feedback" role="alert">
+                                            <strong>{{ $message }}</strong>
+                                        </span>
+                                    @enderror
+                                </div>
+                            </div>
+
+                            <div class="row mb-3">
+                                <div class="col-md-6">
                                     <input id="email" type="email" class="form-control @error('email') is-invalid @enderror" name="email" value="{{ old('email') }}" required autocomplete="email" placeholder="メールアドレス">
 
                                     @error('email')

--- a/src/tufspot/resources/views/back/users/_form.blade.php
+++ b/src/tufspot/resources/views/back/users/_form.blade.php
@@ -112,6 +112,21 @@
 </div>
 
 <div class="form-group row mb-2">
+    {{ Form::label('tufspot_id', 'TUFSPOT ID', ['class' => 'col-sm-2 col-form-label']) }}
+    <div class="col-sm-10">
+        {{ Form::text('tufspot_id', null, [
+            'class' => 'form-control' . ($errors->has('tufspot_id') ? ' is-invalid' : ''),
+            'required',
+        ]) }}
+        @error('tufspot_id')
+            <div class="invalid-feedback">
+                {{ $message }}
+            </div>
+        @enderror
+    </div>
+</div>
+
+<div class="form-group row mb-2">
     {{ Form::label('role', '権限', ['class' => 'col-sm-2 col-form-label']) }}
     <div class="col-sm-10">
         {{ Form::select('role', Auth::user()->role === 2 ? [2 => '執筆者'] : config('common.user.roles'), null, ['class' => 'form-control']) }}

--- a/src/tufspot/resources/views/components/post_card.blade.php
+++ b/src/tufspot/resources/views/components/post_card.blade.php
@@ -27,7 +27,7 @@
             </span>
         </p>
         <div class="post-card-writer-wrapper">
-            <a href="{{ route('writer_detail', ['user' => $post['user']['id']]) }}" class="text-decoration-none">
+            <a href="{{ route('writer_detail', ['user' => $post['user']['name']]) }}" class="text-decoration-none">
                 @if ($post['user']['profile_image_path'])
                     <img loading="lazy" src="{{ $post['user']['profile_image_path'] }}" class="" alt="{{ $post['user']['name'] }} のプロフィール画像" />
                 @else

--- a/src/tufspot/resources/views/components/post_card.blade.php
+++ b/src/tufspot/resources/views/components/post_card.blade.php
@@ -27,7 +27,7 @@
             </span>
         </p>
         <div class="post-card-writer-wrapper">
-            <a href="{{ route('writer_detail', ['user' => $post['user']['name']]) }}" class="text-decoration-none">
+            <a href="{{ route('writer_detail', ['user' => $post['user']['tufspot_id']]) }}" class="text-decoration-none">
                 @if ($post['user']['profile_image_path'])
                     <img loading="lazy" src="{{ $post['user']['profile_image_path'] }}" class="" alt="{{ $post['user']['name'] }} のプロフィール画像" />
                 @else

--- a/src/tufspot/resources/views/components/post_card_carousel.blade.php
+++ b/src/tufspot/resources/views/components/post_card_carousel.blade.php
@@ -35,7 +35,7 @@
                 {{-- <a href="{{ route('hashtag_result', ['tagSlug' => 1]) }}" class="text-decoration-none">#ハッシュタグ</a> --}}
             </p>
             <div class="post-card-writer-wrapper">
-                <a href="{{ route('writer_detail', ['user' => $post['user']['id']]) }}" class="text-decoration-none">
+                <a href="{{ route('writer_detail', ['user' => $post['user']['name']]) }}" class="text-decoration-none">
                     @if ($post['user']['profile_image_path'])
                         <img loading="lazy" src="{{ $post['user']['profile_image_path'] }}" class="" alt="{{ $post['user']['name'] }} のプロフィール画像" />
                     @else

--- a/src/tufspot/resources/views/components/post_card_carousel.blade.php
+++ b/src/tufspot/resources/views/components/post_card_carousel.blade.php
@@ -35,7 +35,7 @@
                 {{-- <a href="{{ route('hashtag_result', ['tagSlug' => 1]) }}" class="text-decoration-none">#ハッシュタグ</a> --}}
             </p>
             <div class="post-card-writer-wrapper">
-                <a href="{{ route('writer_detail', ['user' => $post['user']['name']]) }}" class="text-decoration-none">
+                <a href="{{ route('writer_detail', ['user' => $post['user']['tufspot_id']]) }}" class="text-decoration-none">
                     @if ($post['user']['profile_image_path'])
                         <img loading="lazy" src="{{ $post['user']['profile_image_path'] }}" class="" alt="{{ $post['user']['name'] }} のプロフィール画像" />
                     @else

--- a/src/tufspot/resources/views/components/writer_card.blade.php
+++ b/src/tufspot/resources/views/components/writer_card.blade.php
@@ -1,5 +1,5 @@
 <div class="writer-card d-flex flex-wrap flex-column align-content-center" wire:key="writer-{{ $writer->id }}">
-    <a href="{{ route('writer_detail', ['user' => $writer['id']]) }}" class="text-decoration-none">
+    <a href="{{ route('writer_detail', ['user' => $writer['name']]) }}" class="text-decoration-none">
         <div class="d-flex flex-wrap flex-column justify-content-center align-content-center">
             @if ($writer['profile_image_path'])
                 <img loading="lazy" src="{{ $writer['profile_image_path'] }}" class="" alt="{{ $writer['name'] }} のプロフィール画像" style="height: 100px; width: 100px;" />

--- a/src/tufspot/resources/views/components/writer_card.blade.php
+++ b/src/tufspot/resources/views/components/writer_card.blade.php
@@ -1,5 +1,5 @@
 <div class="writer-card d-flex flex-wrap flex-column align-content-center" wire:key="writer-{{ $writer->id }}">
-    <a href="{{ route('writer_detail', ['user' => $writer['name']]) }}" class="text-decoration-none">
+    <a href="{{ route('writer_detail', ['user' => $writer['tufspot_id']]) }}" class="text-decoration-none">
         <div class="d-flex flex-wrap flex-column justify-content-center align-content-center">
             @if ($writer['profile_image_path'])
                 <img loading="lazy" src="{{ $writer['profile_image_path'] }}" class="" alt="{{ $writer['name'] }} のプロフィール画像" style="height: 100px; width: 100px;" />

--- a/src/tufspot/resources/views/components/writer_explain.blade.php
+++ b/src/tufspot/resources/views/components/writer_explain.blade.php
@@ -2,7 +2,7 @@
     <x-writer_card :writer=$writer />
     <div class="writer-explain-wrapper">
         <div class="writer-explain">
-            <a href="{{ route('writer_detail', ['user' => $writer['name']]) }}" class="text-decoration-none">
+            <a href="{{ route('writer_detail', ['user' => $writer['tufspot_id']]) }}" class="text-decoration-none">
                 <p class="writer-explain-title">▼自己紹介</p>
                 <p class="writer-explain-text">
                     {!! nl2br($writer['introduction']) !!}
@@ -37,7 +37,7 @@
                 <a href="{{ route('hashtag_result', ['tagSlug' => 1]) }}" class="text-decoration-none">#ハッシュタグ</a> --}}
             </p>
         </div>
-        <a href="{{ route('writer_detail', ['user' => $writer['name']]) }}" class="writer-link text-decoration-none">
+        <a href="{{ route('writer_detail', ['user' => $writer['tufspot_id']]) }}" class="writer-link text-decoration-none">
             <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="align-text-top d-inline bi bi-arrow-right" viewBox="0 0 16 16">
                 <path fill-rule="evenodd" d="M1 8a.5.5 0 0 1 .5-.5h11.793l-3.147-3.146a.5.5 0 0 1 .708-.708l4 4a.5.5 0 0 1 0 .708l-4 4a.5.5 0 0 1-.708-.708L13.293 8.5H1.5A.5.5 0 0 1 1 8z" />
             </svg>

--- a/src/tufspot/resources/views/components/writer_explain.blade.php
+++ b/src/tufspot/resources/views/components/writer_explain.blade.php
@@ -2,7 +2,7 @@
     <x-writer_card :writer=$writer />
     <div class="writer-explain-wrapper">
         <div class="writer-explain">
-            <a href="{{ route('writer_detail', ['user' => $writer['id']]) }}" class="text-decoration-none">
+            <a href="{{ route('writer_detail', ['user' => $writer['name']]) }}" class="text-decoration-none">
                 <p class="writer-explain-title">▼自己紹介</p>
                 <p class="writer-explain-text">
                     {!! nl2br($writer['introduction']) !!}
@@ -37,7 +37,7 @@
                 <a href="{{ route('hashtag_result', ['tagSlug' => 1]) }}" class="text-decoration-none">#ハッシュタグ</a> --}}
             </p>
         </div>
-        <a href="{{ route('writer_detail', ['user' => $writer['id']]) }}" class="writer-link text-decoration-none">
+        <a href="{{ route('writer_detail', ['user' => $writer['name']]) }}" class="writer-link text-decoration-none">
             <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="align-text-top d-inline bi bi-arrow-right" viewBox="0 0 16 16">
                 <path fill-rule="evenodd" d="M1 8a.5.5 0 0 1 .5-.5h11.793l-3.147-3.146a.5.5 0 0 1 .708-.708l4 4a.5.5 0 0 1 0 .708l-4 4a.5.5 0 0 1-.708-.708L13.293 8.5H1.5A.5.5 0 0 1 1 8z" />
             </svg>

--- a/src/tufspot/resources/views/mypage.blade.php
+++ b/src/tufspot/resources/views/mypage.blade.php
@@ -20,6 +20,7 @@
                     <div class="d-flex flex-wrap flex-column justify-content-center align-content-center">
                         <div class="user-info-text">
                             <p>名前：{{ $user->name }}</p>
+                            <p>TUFSPOT ID：{{ $user->tufspot_id }}</p>
                             <p>電話番号：{{ $user->gaigokaiMembers[0]['phone_number'] }}</p>
                             <p>メールアドレス：{{ $user->email }}</p>
                             <p>外語会ID：{{ $user->gaigokaiMembers[0]['id'] }}</p>

--- a/src/tufspot/resources/views/mypage.blade.php
+++ b/src/tufspot/resources/views/mypage.blade.php
@@ -92,6 +92,20 @@
                             </div>
                         </div>
                         <div class="form-group ">
+                            {{ Form::label('tufspot_id', 'TUFSPOT ID', ['class' => 'col-form-label']) }}
+                            <div class="">
+                                {{ Form::text('tufspot_id', null, [
+                                    'class' => 'form-control' . ($errors->has('tufspot_id') ? ' is-invalid' : ''),
+                                    'required',
+                                ]) }}
+                                @error('tufspot_id')
+                                    <div class="invalid-feedback">
+                                        {{ $message }}
+                                    </div>
+                                @enderror
+                            </div>
+                        </div>
+                        <div class="form-group ">
                             {{ Form::label('phone_number', '電話番号', ['class' => 'col-form-label']) }}
                             <div class="">
                                 {{ Form::text('phone_number', null, [

--- a/src/tufspot/resources/views/post_detail.blade.php
+++ b/src/tufspot/resources/views/post_detail.blade.php
@@ -38,7 +38,7 @@
                         </p>
                     </a>
                 @else
-                    <a href="{{ route('writer_detail', ['user' => $post['user']['id']]) }}" class="text-decoration-none">
+                    <a href="{{ route('writer_detail', ['user' => $post['user']['name']]) }}" class="text-decoration-none">
                         <svg class="post-detail-user-icon d-inline text-secondary" xmlns="http://www.w3.org/2000/svg" fill="currentColor" class="bi bi-person-circle" viewBox="0 0 16 16">
                             <path d="M11 6a3 3 0 1 1-6 0 3 3 0 0 1 6 0z" />
                             <path fill-rule="evenodd" d="M0 8a8 8 0 1 1 16 0A8 8 0 0 1 0 8zm8-7a7 7 0 0 0-5.468 11.37C3.242 11.226 4.805 10 8 10s4.757 1.225 5.468 2.37A7 7 0 0 0 8 1z" />
@@ -93,7 +93,7 @@
                             </div>
                         </div>
                     @else
-                        <a href="{{ route('writer_detail', ['user' => $post['user']['id']]) }}" class="text-decoration-none mb-2">
+                        <a href="{{ route('writer_detail', ['user' => $post['user']['name']]) }}" class="text-decoration-none mb-2">
                             <svg class="d-inline text-secondary" xmlns="http://www.w3.org/2000/svg" width="47" height="47" fill="currentColor" class="bi bi-person-circle" viewBox="0 0 16 16">
                                 <path d="M11 6a3 3 0 1 1-6 0 3 3 0 0 1 6 0z" />
                                 <path fill-rule="evenodd" d="M0 8a8 8 0 1 1 16 0A8 8 0 0 1 0 8zm8-7a7 7 0 0 0-5.468 11.37C3.242 11.226 4.805 10 8 10s4.757 1.225 5.468 2.37A7 7 0 0 0 8 1z" />
@@ -103,7 +103,7 @@
                             </p>
                         </a>
                         <div class="writer-card-button-wrapper d-flex flex-wrap my-3 justify-content-around gap-2">
-                            <a href="{{ route('writer_detail', ['user' => $post['user']['id']]) }}" class="post-card-button text-center mb-2">プロフィールを見る</a>
+                            <a href="{{ route('writer_detail', ['user' => $post['user']['name']]) }}" class="post-card-button text-center mb-2">プロフィールを見る</a>
                             @if (!$post->user->isAuthUser())
                                 <livewire:follow :followed_user="$post->user" />
                             @endif

--- a/src/tufspot/resources/views/post_detail.blade.php
+++ b/src/tufspot/resources/views/post_detail.blade.php
@@ -38,7 +38,7 @@
                         </p>
                     </a>
                 @else
-                    <a href="{{ route('writer_detail', ['user' => $post['user']['name']]) }}" class="text-decoration-none">
+                    <a href="{{ route('writer_detail', ['user' => $post['user']['tufspot_id']]) }}" class="text-decoration-none">
                         <svg class="post-detail-user-icon d-inline text-secondary" xmlns="http://www.w3.org/2000/svg" fill="currentColor" class="bi bi-person-circle" viewBox="0 0 16 16">
                             <path d="M11 6a3 3 0 1 1-6 0 3 3 0 0 1 6 0z" />
                             <path fill-rule="evenodd" d="M0 8a8 8 0 1 1 16 0A8 8 0 0 1 0 8zm8-7a7 7 0 0 0-5.468 11.37C3.242 11.226 4.805 10 8 10s4.757 1.225 5.468 2.37A7 7 0 0 0 8 1z" />
@@ -93,7 +93,7 @@
                             </div>
                         </div>
                     @else
-                        <a href="{{ route('writer_detail', ['user' => $post['user']['name']]) }}" class="text-decoration-none mb-2">
+                        <a href="{{ route('writer_detail', ['user' => $post['user']['tufspot_id']]) }}" class="text-decoration-none mb-2">
                             <svg class="d-inline text-secondary" xmlns="http://www.w3.org/2000/svg" width="47" height="47" fill="currentColor" class="bi bi-person-circle" viewBox="0 0 16 16">
                                 <path d="M11 6a3 3 0 1 1-6 0 3 3 0 0 1 6 0z" />
                                 <path fill-rule="evenodd" d="M0 8a8 8 0 1 1 16 0A8 8 0 0 1 0 8zm8-7a7 7 0 0 0-5.468 11.37C3.242 11.226 4.805 10 8 10s4.757 1.225 5.468 2.37A7 7 0 0 0 8 1z" />
@@ -103,7 +103,7 @@
                             </p>
                         </a>
                         <div class="writer-card-button-wrapper d-flex flex-wrap my-3 justify-content-around gap-2">
-                            <a href="{{ route('writer_detail', ['user' => $post['user']['name']]) }}" class="post-card-button text-center mb-2">プロフィールを見る</a>
+                            <a href="{{ route('writer_detail', ['user' => $post['user']['tufspot_id']]) }}" class="post-card-button text-center mb-2">プロフィールを見る</a>
                             @if (!$post->user->isAuthUser())
                                 <livewire:follow :followed_user="$post->user" />
                             @endif


### PR DESCRIPTION
resolve #102

修正箇所が多いので留意点のみ記載しています！

## TUFSPOT ID について
- TUFSPOT 上で利用されるユーザ ID（ハンドルネーム）は `TUFSPOT ID` としています
  - 制約は [note ID](https://www.help-note.com/hc/ja/articles/360011358053) を参考にしています
> ・3〜16文字の英数字
> ・記号は「 _ 」(アンダースコア) がつかえます
- 登録と編集に TUFSPOT ID の項目を増やしています
  - バリデーションメッセージ：`TUFSPOT IDには、半角英数字およびアンダースコアのみを指定してください。`
- TUFSPOT ID が `Taro_Tanaka` である場合には writer ページには http://localhost/writer/Taro_Tanaka でアクセスできます

## post の id について
- post の id は 67743e4 から ULID を主キーとしています
  - このため、`make fresh`（`php artisan migrate:fresh --seed`）の実行が必要です
- ULID は仕様上、順序付き（ordered）であるためソートが可能ですが、ミリ秒単位のタイムスタンプを含みます
  - UUID v4 より長さが短いため、今回はパフォーマンスを考慮して採用しています
  - タイムスタンプの隠ぺいを検討している場合は留意してください