### PR TITLE
feat: 外語会 ID 管理ページ

### DIFF
--- a/src/tufspot/app/Http/Controllers/Back/GaigokaiMemberController.php
+++ b/src/tufspot/app/Http/Controllers/Back/GaigokaiMemberController.php
@@ -6,6 +6,7 @@ use App\Http\Controllers\Controller;
 use App\Http\Requests\GaigokaiMember\UpdateRequest;
 use App\Http\Requests\GaigokaiMember\CreateRequest;
 use App\Models\GaigokaiMember;
+use Illuminate\Support\Facades\DB;
 
 class GaigokaiMemberController extends Controller
 {
@@ -92,8 +93,11 @@ class GaigokaiMemberController extends Controller
      */
     public function destroy(GaigokaiMember $gaigokaiMember)
     {
-        $isSucceeded[] = $gaigokaiMember->users->first() === null ?: $gaigokaiMember->users->first()->delete();
-        $isSucceeded[] = $gaigokaiMember->delete();
+        $isSucceeded = DB::transaction(function () use ($gaigokaiMember) {
+            $isSucceeded[] = $gaigokaiMember->users->first() === null ?: $gaigokaiMember->users->first()->delete();
+            $isSucceeded[] = $gaigokaiMember->delete();
+            return $isSucceeded;
+        });
 
         $flash =  match (in_array(false, $isSucceeded)) {
             false => ['success' => 'データを削除しました。'],

--- a/src/tufspot/app/Http/Controllers/Back/GaigokaiMemberController.php
+++ b/src/tufspot/app/Http/Controllers/Back/GaigokaiMemberController.php
@@ -92,7 +92,7 @@ class GaigokaiMemberController extends Controller
      */
     public function destroy(GaigokaiMember $gaigokaiMember)
     {
-        $isSucceeded[] = $gaigokaiMember->users->first()->delete();
+        $isSucceeded[] = $gaigokaiMember->users->first() === null ?: $gaigokaiMember->users->first()->delete();
         $isSucceeded[] = $gaigokaiMember->delete();
 
         $flash =  match (in_array(false, $isSucceeded)) {

--- a/src/tufspot/app/Http/Controllers/Back/GaigokaiMemberController.php
+++ b/src/tufspot/app/Http/Controllers/Back/GaigokaiMemberController.php
@@ -92,11 +92,12 @@ class GaigokaiMemberController extends Controller
      */
     public function destroy(GaigokaiMember $gaigokaiMember)
     {
-        $isSucceeded = $gaigokaiMember->delete();
+        $isSucceeded[] = $gaigokaiMember->users->first()->delete();
+        $isSucceeded[] = $gaigokaiMember->delete();
 
-        $flash =  match ($isSucceeded) {
-            true => ['success' => 'データを削除しました。'],
-            false => ['error' => 'データの削除に失敗しました。'],
+        $flash =  match (in_array(false, $isSucceeded)) {
+            false => ['success' => 'データを削除しました。'],
+            true => ['error' => 'データの削除に失敗しました。'],
         };
 
         return redirect()

--- a/src/tufspot/app/Http/Controllers/Back/GaigokaiMemberController.php
+++ b/src/tufspot/app/Http/Controllers/Back/GaigokaiMemberController.php
@@ -38,7 +38,7 @@ class GaigokaiMemberController extends Controller
      */
     public function store(CreateRequest $request)
     {
-        $gaigokaiMember = GaigokaiMember::create($request->all());
+        $gaigokaiMember = GaigokaiMember::create($request->validated());
 
         if ($gaigokaiMember) {
             return redirect()
@@ -71,7 +71,7 @@ class GaigokaiMemberController extends Controller
      */
     public function update(UpdateRequest $request, GaigokaiMember $gaigokaiMember)
     {
-        $isSucceeded = $gaigokaiMember->update(['phone_number' => $request->phone_number]);
+        $isSucceeded = $gaigokaiMember->update($request->validated());
 
         $flash = match ($isSucceeded) {
             true => ['success' => 'データを更新しました。'],

--- a/src/tufspot/app/Http/Controllers/Back/GaigokaiMemberController.php
+++ b/src/tufspot/app/Http/Controllers/Back/GaigokaiMemberController.php
@@ -1,0 +1,106 @@
+<?php
+
+namespace App\Http\Controllers\Back;
+
+use App\Http\Controllers\Controller;
+use App\Http\Requests\GaigokaiMember\UpdateRequest;
+use App\Http\Requests\GaigokaiMember\CreateRequest;
+use App\Models\GaigokaiMember;
+
+class GaigokaiMemberController extends Controller
+{
+    /**
+     * 一覧画面
+     *
+     * @return \Illuminate\Contracts\View\View
+     */
+    public function index()
+    {
+        $gaigokaiMembers = GaigokaiMember::orderByDesc('id')->paginate(20);
+        return view('back.gaigokaiMembers.index', compact('gaigokaiMembers'));
+    }
+
+    /**
+     * 登録画面
+     *
+     * @return \Illuminate\Contracts\View\View
+     */
+    public function create()
+    {
+        return view('back.gaigokaiMembers.create');
+    }
+
+    /**
+     * 登録処理
+     *
+     * @param App\Http\Requests\GaigokaiMember\CreateRequest $request
+     * @return \Illuminate\Http\RedirectResponse
+     */
+    public function store(CreateRequest $request)
+    {
+        $gaigokaiMember = GaigokaiMember::create($request->all());
+
+        if ($gaigokaiMember) {
+            return redirect()
+                ->route('back.gaigokaiMembers.edit', $gaigokaiMember)
+                ->withSuccess('データを登録しました。');
+        } else {
+            return redirect()
+                ->route('back.gaigokaiMembers.create')
+                ->withError('データの登録に失敗しました。');
+        }
+    }
+
+    /**
+     * 編集画面
+     *
+     * @param GaigokaiMember $gaigokaiMember
+     * @return \Illuminate\Contracts\View\View
+     */
+    public function edit(GaigokaiMember $gaigokaiMember)
+    {
+        return view('back.gaigokaiMembers.edit', compact('gaigokaiMember'));
+    }
+
+    /**
+     * 更新処理
+     *
+     * @param  App\Http\Requests\GaigokaiMember\UpdateRequest $request
+     * @param  \App\Models\GaigokaiMember $gaigokaiMember
+     * @return \Illuminate\Http\RedirectResponse
+     */
+    public function update(UpdateRequest $request, GaigokaiMember $gaigokaiMember)
+    {
+        $isSucceeded = $gaigokaiMember->update(['phone_number' => $request->phone_number]);
+
+        $flash = match ($isSucceeded) {
+            true => ['success' => 'データを更新しました。'],
+            false => ['error' => 'データの更新に失敗しました'],
+        };
+
+        return redirect()
+            ->route('back.gaigokaiMembers.edit', compact('gaigokaiMember'))
+            ->with($flash);
+    }
+
+    /**
+     * Remove the specified resource from storage.
+     *
+     * @param  \App\Models\GaigokaiMember $gaigokaiMember
+     * @return \Illuminate\Http\RedirectResponse
+     * @throws \Exception
+     */
+    public function destroy(GaigokaiMember $gaigokaiMember)
+    {
+        $isSucceeded = $gaigokaiMember->delete();
+
+        $flash =  match ($isSucceeded) {
+            true => ['success' => 'データを削除しました。'],
+            false => ['error' => 'データの削除に失敗しました。'],
+        };
+
+        return redirect()
+            ->route('back.gaigokaiMembers.index')
+            ->with($flash);
+    }
+}

--- a/src/tufspot/app/Http/Controllers/Back/GaigokaiMemberController.php
+++ b/src/tufspot/app/Http/Controllers/Back/GaigokaiMemberController.php
@@ -16,7 +16,7 @@ class GaigokaiMemberController extends Controller
      */
     public function index()
     {
-        $gaigokaiMembers = GaigokaiMember::orderByDesc('id')->paginate(20);
+        $gaigokaiMembers = GaigokaiMember::with('users')->orderByDesc('id')->paginate(20);
         return view('back.gaigokaiMembers.index', compact('gaigokaiMembers'));
     }
 

--- a/src/tufspot/app/Http/Requests/GaigokaiMember/CreateRequest.php
+++ b/src/tufspot/app/Http/Requests/GaigokaiMember/CreateRequest.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace App\Http\Requests\GaigokaiMember;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class CreateRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     */
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array
+     */
+    public function rules()
+    {
+        $validate = [
+            'id' => ['required', 'string'],
+            'phone_number' => ['required', 'regex:/^\+?[0-9]{1,15}$/'],
+        ];
+
+        return $validate;
+    }
+
+    /**
+     * 定義済みバリデーションルールのエラーメッセージ取得
+     *
+     * @return array<string, string>
+     */
+    public function messages(): array
+    {
+        return [
+            'phone_number.regex' => '電話番号は、先頭のみ記号 + を許容し、以降は数字を 15 桁まで指定できます（ITU-T E.164 に準拠）。',
+        ];
+    }
+}

--- a/src/tufspot/app/Http/Requests/GaigokaiMember/CreateRequest.php
+++ b/src/tufspot/app/Http/Requests/GaigokaiMember/CreateRequest.php
@@ -22,8 +22,8 @@ class CreateRequest extends FormRequest
     public function rules()
     {
         $validate = [
-            'id' => ['required', 'string'],
-            'phone_number' => ['required', 'regex:/^\+?[0-9]{1,15}$/'],
+            'id' => ['required', 'string', 'unique:gaigokai_members,id'],
+            'phone_number' => ['required', 'regex:/^\+?[0-9]{1,15}$/', 'unique:gaigokai_members,phone_number']
         ];
 
         return $validate;
@@ -37,6 +37,8 @@ class CreateRequest extends FormRequest
     public function messages(): array
     {
         return [
+            'id.unique' => 'すでに登録されている外語会 ID です。',
+            'phone_number.unique' => 'すでに登録されている電話番号です。',
             'phone_number.regex' => '電話番号は、先頭のみ記号 + を許容し、以降は数字を 15 桁まで指定できます（ITU-T E.164 に準拠）。',
         ];
     }

--- a/src/tufspot/app/Http/Requests/GaigokaiMember/UpdateRequest.php
+++ b/src/tufspot/app/Http/Requests/GaigokaiMember/UpdateRequest.php
@@ -3,6 +3,7 @@
 namespace App\Http\Requests\GaigokaiMember;
 
 use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Rule;
 
 class UpdateRequest extends FormRequest
 {
@@ -22,7 +23,18 @@ class UpdateRequest extends FormRequest
     public function rules()
     {
         $validate = [
-            'phone_number' => ['required', 'regex:/^\+?[0-9]{1,15}$/'],
+            'id' => [
+                'sometimes',
+                'required',
+                'string',
+                Rule::unique('gaigokai_members', 'id')->ignore($this->gaigokaiMember->id)
+            ],
+            'phone_number' => [
+                'sometimes',
+                'required',
+                'regex:/^\+?[0-9]{1,15}$/',
+                Rule::unique('gaigokai_members', 'phone_number')->ignore($this->gaigokaiMember->id)
+            ]
         ];
 
         return $validate;
@@ -36,6 +48,8 @@ class UpdateRequest extends FormRequest
     public function messages(): array
     {
         return [
+            'id.unique' => 'すでに登録されている外語会 ID です。',
+            'phone_number.unique' => 'すでに登録されている電話番号です。',
             'phone_number.regex' => '電話番号は、先頭のみ記号 + を許容し、以降は数字を 15 桁まで指定できます（ITU-T E.164 に準拠）。',
         ];
     }

--- a/src/tufspot/app/Http/Requests/GaigokaiMember/UpdateRequest.php
+++ b/src/tufspot/app/Http/Requests/GaigokaiMember/UpdateRequest.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace App\Http\Requests\GaigokaiMember;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class UpdateRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     */
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array
+     */
+    public function rules()
+    {
+        $validate = [
+            'phone_number' => ['required', 'regex:/^\+?[0-9]{1,15}$/'],
+        ];
+
+        return $validate;
+    }
+
+    /**
+     * 定義済みバリデーションルールのエラーメッセージ取得
+     *
+     * @return array<string, string>
+     */
+    public function messages(): array
+    {
+        return [
+            'phone_number.regex' => '電話番号は、先頭のみ記号 + を許容し、以降は数字を 15 桁まで指定できます（ITU-T E.164 に準拠）。',
+        ];
+    }
+}

--- a/src/tufspot/database/migrations/2023_09_20_103606_create_gaigokai_members_table.php
+++ b/src/tufspot/database/migrations/2023_09_20_103606_create_gaigokai_members_table.php
@@ -26,7 +26,7 @@ return new class extends Migration
             $table->increments('id');
             $table->string('gaigokai_member_id')->unique();
             $table->foreignId('user_id')->constrained()->onDelete('cascade');
-            $table->foreign('gaigokai_member_id')->references('id')->on('gaigokai_members')->onUpdate('cascade');
+            $table->foreign('gaigokai_member_id')->references('id')->on('gaigokai_members')->onDelete('cascade')->onUpdate('cascade');
         });
     }
 

--- a/src/tufspot/database/migrations/2023_09_20_103606_create_gaigokai_members_table.php
+++ b/src/tufspot/database/migrations/2023_09_20_103606_create_gaigokai_members_table.php
@@ -26,7 +26,7 @@ return new class extends Migration
             $table->increments('id');
             $table->string('gaigokai_member_id')->unique();
             $table->foreignId('user_id')->constrained()->onDelete('cascade');
-            $table->foreign('gaigokai_member_id')->references('id')->on('gaigokai_members')->onDelete('cascade');
+            $table->foreign('gaigokai_member_id')->references('id')->on('gaigokai_members')->onUpdate('cascade');
         });
     }
 

--- a/src/tufspot/database/migrations/2023_09_20_103606_create_gaigokai_members_table.php
+++ b/src/tufspot/database/migrations/2023_09_20_103606_create_gaigokai_members_table.php
@@ -26,7 +26,7 @@ return new class extends Migration
             $table->increments('id');
             $table->string('gaigokai_member_id')->unique();
             $table->foreignId('user_id')->constrained()->onDelete('cascade');
-            $table->foreign('gaigokai_member_id')->references('id')->on('gaigokai_members');
+            $table->foreign('gaigokai_member_id')->references('id')->on('gaigokai_members')->onDelete('cascade');
         });
     }
 

--- a/src/tufspot/resources/views/back/gaigokaiMembers/_form.blade.php
+++ b/src/tufspot/resources/views/back/gaigokaiMembers/_form.blade.php
@@ -2,22 +2,26 @@
 /**
  * @var \App\Models\GaigokaiMember $gaigokaiMember
  */
-$textControl = Illuminate\Support\Facades\Route::currentRouteName() === 'back.gaigokaiMembers.edit' ? 'disabled' : 'required';
 ?>
 <div class="form-group row mb-2">
     {{ Form::label('id', '外語会 ID', ['class' => 'col-sm-2 col-form-label']) }}
     <div class="col-sm-10">
-        {{ Form::text('id', $gaigokaiMember['id'] ?? null, [
+        {{ Form::text('id', null, [
             'class' => 'form-control' . ($errors->has('id') ? ' is-invalid' : ''),
-            "$textControl",
+            'required',
         ]) }}
+        @error('id')
+            <div class="invalid-feedback">
+                {{ $message }}
+            </div>
+        @enderror
     </div>
 </div>
 
 <div class="form-group row mb-2">
     {{ Form::label('phone_number', '電話番号', ['class' => 'col-sm-2 col-form-label']) }}
     <div class="col-sm-10">
-        {{ Form::text('phone_number', $gaigokaiMember['phone_number'] ?? null, [
+        {{ Form::text('phone_number', null, [
             'class' => 'form-control' . ($errors->has('phone_number') ? ' is-invalid' : ''),
             'required',
         ]) }}

--- a/src/tufspot/resources/views/back/gaigokaiMembers/_form.blade.php
+++ b/src/tufspot/resources/views/back/gaigokaiMembers/_form.blade.php
@@ -1,0 +1,39 @@
+<?php
+/**
+ * @var \App\Models\GaigokaiMember $gaigokaiMember
+ */
+$textControl = Illuminate\Support\Facades\Route::currentRouteName() === 'back.gaigokaiMembers.edit' ? 'disabled' : 'required';
+?>
+<div class="form-group row mb-2">
+    {{ Form::label('id', '外語会 ID', ['class' => 'col-sm-2 col-form-label']) }}
+    <div class="col-sm-10">
+        {{ Form::text('id', $gaigokaiMember['id'] ?? null, [
+            'class' => 'form-control' . ($errors->has('id') ? ' is-invalid' : ''),
+            "$textControl",
+        ]) }}
+    </div>
+</div>
+
+<div class="form-group row mb-2">
+    {{ Form::label('phone_number', '電話番号', ['class' => 'col-sm-2 col-form-label']) }}
+    <div class="col-sm-10">
+        {{ Form::text('phone_number', $gaigokaiMember['phone_number'] ?? null, [
+            'class' => 'form-control' . ($errors->has('phone_number') ? ' is-invalid' : ''),
+            'required',
+        ]) }}
+        @error('phone_number')
+            <div class="invalid-feedback">
+                {{ $message }}
+            </div>
+        @enderror
+    </div>
+</div>
+
+<div class="d-flex justify-content-between mt-4 mb-4">
+    <div class="">
+        {{ link_to_route('back.gaigokaiMembers.index', '一覧へ', null, ['class' => 'btn btn-outline-dark']) }}
+    </div>
+    <div class="">
+        <button type="submit" class="btn btn-success" name="subbtn">保存</button>
+    </div>
+</div>

--- a/src/tufspot/resources/views/back/gaigokaiMembers/create.blade.php
+++ b/src/tufspot/resources/views/back/gaigokaiMembers/create.blade.php
@@ -1,0 +1,20 @@
+<?php
+/**
+ * @var \App\Models\GaigokaiMember $gaigokaiMember
+ */
+$title = '外語会 ID 登録';
+?>
+@extends('back.layouts.base')
+
+@section('content')
+    {!! Form::open([
+        'method' => 'post',
+        'route' => 'back.gaigokaiMembers.store',
+    ]) !!}
+    <div class="d-flex justify-content-between flex-wrap flex-md-nowrap align-items-center pt-3 pb-2 mb-3 border-bottom">
+        <h1 class="h2">{{ $title }}</h1>
+    </div>
+    @include('back.gaigokaiMembers._form')
+
+    {!! Form::close() !!}
+@endsection

--- a/src/tufspot/resources/views/back/gaigokaiMembers/edit.blade.php
+++ b/src/tufspot/resources/views/back/gaigokaiMembers/edit.blade.php
@@ -1,0 +1,32 @@
+<?php
+/**
+ * @var \App\Models\GaigokaiMember $gaigokaiMember
+ */
+$title = '外語会 ID 編集';
+?>
+@extends('back.layouts.base')
+
+@section('content')
+    {!! Form::model($gaigokaiMember, [
+        'route' => ['back.gaigokaiMembers.update', $gaigokaiMember],
+        'method' => 'put',
+        'files' => true,
+        'enctype' => 'multipart/form-data',
+    ]) !!}
+    <div class="d-flex justify-content-between flex-wrap flex-md-nowrap align-items-center pt-3 pb-2 mb-3 border-bottom">
+        <h1 class="h2">{{ $title }}</h1>
+    </div>
+    @include('back.gaigokaiMembers._form')
+    {!! Form::close() !!}
+    <table class="table">
+        <tr>
+            <th>登録日時</th>
+            <td>{{ $gaigokaiMember->created_at ?? '（初期登録されています）' }}</td>
+        </tr>
+        <tr>
+            <th>編集日時</th>
+            <td>{{ $gaigokaiMember->updated_at ?? '（編集されていません）' }}</td>
+        </tr>
+    </table>
+    </div>
+@endsection

--- a/src/tufspot/resources/views/back/gaigokaiMembers/index.blade.php
+++ b/src/tufspot/resources/views/back/gaigokaiMembers/index.blade.php
@@ -1,0 +1,83 @@
+<?php
+/**
+ * @var Illuminate\Pagination\LengthAwarePaginator|\App\Models\GaigokaiMember[] $gaigokaiMembers
+ */
+$title = '外語会 ID 一覧';
+
+?>
+@extends('back.layouts.base')
+
+@section('content')
+    <div class="d-flex justify-content-between flex-wrap flex-md-nowrap align-items-center pt-3 pb-2 mb-3 border-bottom">
+        <h1 class="h2">{{ $title }}</h1>
+        <div class="btn-toolbar mb-2 mb-md-0">
+            <a href="{{ route('back.gaigokaiMembers.create') }}" class="btn btn-success">
+                <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-pencil-fill v" viewBox="0 0 16 16">
+                    <path d="M12.854.146a.5.5 0 0 0-.707 0L10.5 1.793 14.207 5.5l1.647-1.646a.5.5 0 0 0 0-.708l-3-3zm.646 6.061L9.793 2.5 3.293 9H3.5a.5.5 0 0 1 .5.5v.5h.5a.5.5 0 0 1 .5.5v.5h.5a.5.5 0 0 1 .5.5v.5h.5a.5.5 0 0 1 .5.5v.207l6.5-6.5zm-7.468 7.468A.5.5 0 0 1 6 13.5V13h-.5a.5.5 0 0 1-.5-.5V12h-.5a.5.5 0 0 1-.5-.5V11h-.5a.5.5 0 0 1-.5-.5V10h-.5a.499.499 0 0 1-.175-.032l-.179.178a.5.5 0 0 0-.11.168l-2 5a.5.5 0 0 0 .65.65l5-2a.5.5 0 0 0 .168-.11l.178-.178z" />
+                </svg>
+                登録
+            </a>
+        </div>
+    </div>
+    @if (0 < $gaigokaiMembers->count())
+        <div class="table-responsive">
+            <table class="table ">
+                <thead>
+                    <tr>
+                        <th scope="col" style="width: 2em" class="text-nowrap">外語会 ID</th>
+                        <th scope="col" style="width: 10em" class="text-nowrap">電話番号</th>
+                        <th scope="col" style="width: 10em" class="text-nowrap">登録日時</th>
+                        <th scope="col" style="width: 10em" class="text-nowrap">編集日時</th>
+                        <th scope="col" style="width: 5em" class="text-nowrap"></th>
+                        <th scope="col" style=""></th>
+                    </tr>
+                </thead>
+                <tbody>
+                    @foreach ($gaigokaiMembers as $member)
+                        <tr>
+                            <td>{{ $member->id }}</td>
+                            <td>{{ $member->phone_number }}</td>
+                            <td>{{ $member->created_at ?? '（初期登録）' }}</td>
+                            <td>{{ $member->updated_at ?? '（未編集）' }}</td>
+                            <td>
+                                {{ link_to_route('back.gaigokaiMembers.edit', '編集', $member, [
+                                    'class' => 'btn btn-outline-dark btn-sm m-1',
+                                ]) }}
+                            </td>
+                            <td>
+                                <div class="dropdown">
+                                    <a class="text-decoration-none link-dark pb-3" href="#" role="button" id="dropdownMenuLink" data-bs-toggle="dropdown" aria-expanded="false">
+                                        <svg xmlns="http://www.w3.org/2000/svg" width="25" height="25" fill="currentColor" class="bi bi-three-dots" viewBox="0 0 16 16">
+                                            <path d="M3 9.5a1.5 1.5 0 1 1 0-3 1.5 1.5 0 0 1 0 3zm5 0a1.5 1.5 0 1 1 0-3 1.5 1.5 0 0 1 0 3zm5 0a1.5 1.5 0 1 1 0-3 1.5 1.5 0 0 1 0 3z" />
+                                        </svg>
+                                    </a>
+                                    <ul class="dropdown-menu" aria-labelledby="dropdownMenuButton1">
+                                        <li>
+                                            {{ Form::model($member, [
+                                                'route' => ['back.gaigokaiMembers.destroy', $member],
+                                                'method' => 'delete',
+                                            ]) }}
+                                            {{ Form::submit('削除', [
+                                                'onclick' => "return confirm('本当に削除しますか?')",
+                                                'class' => 'dropdown-item text-danger',
+                                            ]) }}
+                                            {{ Form::close() }}
+                                        </li>
+                                    </ul>
+                                </div>
+                            </td>
+                        </tr>
+                    @endforeach
+                </tbody>
+            </table>
+        </div>
+        <div class="d-flex justify-content-center">
+            <nav aria-label="Page navigation example">
+                <ul class="pagination">
+                    {{ $gaigokaiMembers->links() }}
+                </ul>
+            </nav>
+        </div>
+    @endif
+    </div>
+@endsection

--- a/src/tufspot/resources/views/back/gaigokaiMembers/index.blade.php
+++ b/src/tufspot/resources/views/back/gaigokaiMembers/index.blade.php
@@ -25,9 +25,9 @@ $title = '外語会 ID 一覧';
                 <thead>
                     <tr>
                         <th scope="col" style="width: 2em" class="text-nowrap">外語会 ID</th>
+                        <th scope="col" style="width: 10em" class="text-nowrap">TUFSPOT ID</th>
+                        <th scope="col" style="width: 10em" class="text-nowrap">名前</th>
                         <th scope="col" style="width: 10em" class="text-nowrap">電話番号</th>
-                        <th scope="col" style="width: 10em" class="text-nowrap">登録日時</th>
-                        <th scope="col" style="width: 10em" class="text-nowrap">編集日時</th>
                         <th scope="col" style="width: 5em" class="text-nowrap"></th>
                         <th scope="col" style=""></th>
                     </tr>
@@ -36,9 +36,9 @@ $title = '外語会 ID 一覧';
                     @foreach ($gaigokaiMembers as $member)
                         <tr>
                             <td>{{ $member->id }}</td>
+                            <td>{{ $member->users->first()->tufspot_id ?? '' }}</td>
+                            <td>{{ $member->users->first()->name ?? '' }}</td>
                             <td>{{ $member->phone_number }}</td>
-                            <td>{{ $member->created_at ?? '（初期登録）' }}</td>
-                            <td>{{ $member->updated_at ?? '（未編集）' }}</td>
                             <td>
                                 {{ link_to_route('back.gaigokaiMembers.edit', '編集', $member, [
                                     'class' => 'btn btn-outline-dark btn-sm m-1',

--- a/src/tufspot/resources/views/back/layouts/base.blade.php
+++ b/src/tufspot/resources/views/back/layouts/base.blade.php
@@ -101,6 +101,9 @@
                         <li class="nav-item">
                             <a class="nav-link" href="{{ route('back.users.index') }}">ユーザー</a>
                         </li>
+                        <li class="nav-item">
+                            <a class="nav-link" href="{{ route('back.gaigokaiMembers.index') }}">外語会 ID</a>
+                        </li>
                     @endif
                     <li class="nav-item">
                         <a class="nav-link active" aria-current="page" href="{{ route('index') }}" target="_blank" rel="noopener noreferrer">本番サイトへ</a>

--- a/src/tufspot/resources/views/back/users/index.blade.php
+++ b/src/tufspot/resources/views/back/users/index.blade.php
@@ -24,7 +24,7 @@ $title = 'ユーザー一覧';
             <table class="table ">
                 <thead>
                     <tr>
-                        <th scope="col" style="width: 2em" class="text-nowrap">ID</th>
+                        <th scope="col" style="width: 10em" class="text-nowrap">TUFSPOT ID</th>
                         <th scope="col" style="width: 10em" class="text-nowrap">ユーザー名</th>
                         <th scope="col" style="width: 10em" class="text-nowrap">メールアドレス</th>
                         <th scope="col" style="width: 5em" class="text-nowrap">権限</th>
@@ -35,7 +35,7 @@ $title = 'ユーザー一覧';
                 <tbody>
                     @foreach ($users as $user)
                         <tr>
-                            <td>{{ $user->id }}</td>
+                            <td>{{ $user->tufspot_id }}</td>
                             <td>{{ $user->name }}</td>
                             <td>{{ $user->email }}</td>
                             <td>{{ $user->role_label }}</td>

--- a/src/tufspot/routes/back.php
+++ b/src/tufspot/routes/back.php
@@ -15,10 +15,12 @@ Route::group(['middleware' => 'can:writer'], function () {
     // 記事プレビュー
     Route::put('preview/{id}', [PostController::class, 'preview'])->name('post_preview');
     Route::post('preview/{id}', [PostController::class, 'preview'])->name('post_preview');
+
     Route::resource('users', 'UserController')->only(['edit', 'update']);
 });
 
 // adminのみアクセス可能
 Route::group(['middleware' => 'can:admin'], function () {
     Route::resource('users', 'UserController')->except(['show', 'edit', 'update']);
+    Route::resource('gaigokaiMembers', 'GaigokaiMemberController');
 });


### PR DESCRIPTION
resolve #83, #123

## 仕様
- 外語会 ID の一覧・登録・削除、外語会 ID と紐づけられている電話番号の編集ができます

## TUFSPOT ユーザと外語会 ID の相関性について
- マイグレーションファイルの制約から読み取っています
    - TUFSPOT に登録済みのユーザの外語会 ID を削除する際、外部キー制約のエラーが発生したため、そこだけ修正しています
- もしマイグレーションファイルにある制約が意図していた挙動と異なっていれば、この PR で修正します！
    - 中間テーブルの該当レコードのみ削除されます
    - 外語会 ID を削除しても、TUFSPOT ユーザは削除されません
    - TUFSPOT ユーザを削除しても、外語会 ID は削除されません 