### PR TITLE
新規登録に新たなリンク設置

### DIFF
--- a/src/tufspot/resources/views/auth/register.blade.php
+++ b/src/tufspot/resources/views/auth/register.blade.php
@@ -89,6 +89,14 @@
                                 </div>
                             </div>
 
+                            <div class="row mb-3">
+                                <div class="col-md-6 text-start">
+                                    <a class="link-secondary" href="https://www.gaigokai.or.jp/inquiry.html">
+                                        外語会ID・電話番号を忘れた方はこちら
+                                    </a>
+                                </div>
+                            </div>
+
                             <div class="row mb-0">
                                 <div class="col-md-6 offset-md-4">
                                     <button type="submit" class="btn btn-primary">

--- a/src/tufspot/resources/views/auth/register.blade.php
+++ b/src/tufspot/resources/views/auth/register.blade.php
@@ -91,7 +91,7 @@
 
                             <div class="row mb-3">
                                 <div class="col-md-6 text-start">
-                                    <a class="link-secondary" href="https://www.gaigokai.or.jp/inquiry.html">
+                                    <a class="link-secondary" href="https://www.gaigokai.or.jp/inquiry.html" target="_blank" rel="noopener noreferrer">
                                         外語会ID・電話番号を忘れた方はこちら
                                     </a>
                                 </div>


### PR DESCRIPTION
#122

変更点：
新規登録ページに東京外語会へのリンク(「[外語会ID・電話番号を忘れた方はこちら](https://www.gaigokai.or.jp/inquiry.html)」)を追加

### 迷った点
- 「パスワード確認欄」と「追加したリンク」間のマージンの大きさ

![image](https://github.com/Tatsuya-328/tufspot_develop/assets/82076335/e78134ba-49fd-42e7-9def-ed1187d8be96)

ログイン画面では、「パスワードを忘れた方はこちら」とのことで 「パスワード欄」と「リンク」間のマージンが狭いと解釈した(近接的な意味合い)けど、今回の場合どうしましょう

・このまま
or
・ログイン画面と同じマージン　≒ もう少し狭くする
で迷いました！


参考：ログイン画面
![img_login](https://user-images.githubusercontent.com/84480954/277587532-a6d6c9f6-e970-4b71-ab1a-f3c43e798a5c.png)
