### PR TITLE
About関連：「About 行間等々#140」「About TUFSPOTとは修正#142」「About、メディアコンセプトの修正#141（Aboutのレスポンシブ時のHover修正#93）」

### DIFF
--- a/src/tufspot/public/css/modules/about.css
+++ b/src/tufspot/public/css/modules/about.css
@@ -26,17 +26,30 @@
 }
 
 .hover-text-area {
-    position: absolute;
+    /* position: absolute;
     top: 0;
     left: 0;
     width: 100%;
     height: 100%;
     background-color: #505050;
-    opacity: 0;
+    opacity: 0; */
+
+    position: absolute;
+    max-width: 625px;
+    width: 100%;
+    height: 250px;
+    background-color: #ffffff;
+    border: 3px solid #505050;
+    font-size: 16px;
+    letter-spacing: 11px;
+    color: #222222;
+    font-weight: 600;
+    box-sizing: border-box;
 }
 
 .hover-text-area:hover {
     cursor: pointer;
+    background-color: #505050;
 }
 
 .hover-text-area.appear {
@@ -59,11 +72,19 @@
     letter-spacing: 5px;
     text-align: center;
     line-height: 160%;
-    padding: 0 10px;
+    padding: 0 10px 0 20px;
+    background-color: #505050;
+
 }
 
 @media screen and (max-width: 768px) {
     .display-only-pc {
         display: none;
+    }
+}
+
+@media screen and (max-width: 991px) {
+    .hover-text-area {
+        height: 300px;
     }
 }

--- a/src/tufspot/public/css/style_uru.css
+++ b/src/tufspot/public/css/style_uru.css
@@ -764,7 +764,14 @@ input[type="radio"] {
 .about-top-text {
   font-size: 17px;
   margin: unset;
-  letter-spacing: 2.5px
+  letter-spacing: 2.5px;
+  line-height: 1.75;
+}
+
+@media (max-width: 600px) {
+  .about-top-text {
+    line-height: 2;
+  }
 }
 
 .about-image {
@@ -887,11 +894,12 @@ input[type="radio"] {
 .about-theme-wrapper {}
 
 .about-theme {
-  margin: 0 43px;
+  width: 240px;
+  margin: 0 36px;
 }
 
 .about-theme-top-text {
-  margin: 200px 0 60px 0;
+  margin: 200px 0 90px 0;
   font-size: 30px;
   letter-spacing: 6px;
   color: #222222;
@@ -2209,9 +2217,9 @@ aside {
     margin-left: 3%;
   }
 
-  .wrapper {
+  /* .wrapper {
     margin-top: 7%;
-  }
+  } */
 
   .account_name {
     /* display: none; */

--- a/src/tufspot/public/css/style_uru.css
+++ b/src/tufspot/public/css/style_uru.css
@@ -838,33 +838,37 @@ input[type="radio"] {
 
 
 .about-concept {
-  margin: 230px 0 0 0;
+  margin: 200px 0 100px 0;
   width: 100%;
   position: relative;
 }
 
 .about-concept-title {
   position: absolute;
-  top: -60px;
-  font-size: 30px;
+  top: -42px;
+  font-size: 16px;
   letter-spacing: 6px;
   color: #ffffff;
-  max-width: 432px;
+  max-width: 260px;
   width: 100%;
-  height: 88px;
+  height: 70px;
   background-color: #505050;
+  border: 3px solid #505050;
 }
 
 .about-concept-text {
-  max-width: 1042px;
+  position: absolute;
+  max-width: 625px;
   width: 100%;
-  height: 238px;
+  height: 250px;
   background-color: #ffffff;
   border: 3px solid #505050;
-  font-size: 53px;
+  font-size: 32px;
   letter-spacing: 11px;
   color: #222222;
   font-weight: 600;
+  box-sizing: border-box;
+  padding-left: 24px;
 }
 
 .about-theme-title {
@@ -891,7 +895,9 @@ input[type="radio"] {
   margin: 50px 0 0 0;
 }
 
-.about-theme-wrapper {}
+.about-theme-wrapper {
+  margin-bottom: 50px;
+}
 
 .about-theme {
   width: 240px;
@@ -899,7 +905,7 @@ input[type="radio"] {
 }
 
 .about-theme-top-text {
-  margin: 200px 0 90px 0;
+  margin: 120px 0 90px 0;
   font-size: 30px;
   letter-spacing: 6px;
   color: #222222;
@@ -924,6 +930,7 @@ input[type="radio"] {
 .about-concept-spot-title {
   font-size: 18px;
   letter-spacing: 4px;
+  margin-left: -16px;
 }
 
 .about-concept-spot-title {

--- a/src/tufspot/public/css/style_uru.css
+++ b/src/tufspot/public/css/style_uru.css
@@ -919,18 +919,20 @@ input[type="radio"] {
 }
 
 .about-concept-spot-title {
+  max-width: 770px;
   white-space: nowrap;
   font-size: 15px;
-  margin-right: auto;
-  margin-left: 18px;
+  width: 100%;
 }
 
 .about-concept-spot-headline {
-  margin: 0 auto 30px 24px;
+  max-width: 770px;
+  margin: 0 0 30px 0;
   letter-spacing: 10px;
   font-weight: 800;
   white-space: nowrap;
   font-size: 48px;
+  width: 100%;
 }
 
 
@@ -941,10 +943,12 @@ input[type="radio"] {
 @media (max-width:992px) {
   .about-concept-spot-title {
     margin: 0 auto;
+    text-align: center;
   }
 
   .about-concept-spot-headline {
     margin: 0 0 30px 0;
+    text-align: center;
   }
 }
 

--- a/src/tufspot/public/css/style_uru.css
+++ b/src/tufspot/public/css/style_uru.css
@@ -879,7 +879,7 @@ input[type="radio"] {
   margin: 0 0 30px 0;
   max-width: 250px;
   width: 100%;
-  white-wrap: nowrap;
+  word-wrap: normal;
 }
 
 .about-theme-title>span {
@@ -887,6 +887,7 @@ input[type="radio"] {
 }
 
 .about-theme-text {
+  word-break: auto-phrase;
   font-size: 14px;
   letter-spacing: 3px;
   color: #222222;

--- a/src/tufspot/public/css/style_uru.css
+++ b/src/tufspot/public/css/style_uru.css
@@ -905,7 +905,7 @@ input[type="radio"] {
 .about-concept-spot {
   margin: 0 auto 100px auto;
   width: 1000px;
-  width: 100%;
+  width: 90%;
 
 }
 
@@ -921,18 +921,31 @@ input[type="radio"] {
 .about-concept-spot-title {
   white-space: nowrap;
   font-size: 15px;
+  margin-right: auto;
+  margin-left: 18px;
 }
 
 .about-concept-spot-headline {
-  margin: 0 0 30px 0;
+  margin: 0 auto 30px 24px;
   letter-spacing: 10px;
   font-weight: 800;
   white-space: nowrap;
   font-size: 48px;
 }
 
+
 .about-concept-spot-detail {
   padding: 0 10px;
+}
+
+@media (max-width:992px) {
+  .about-concept-spot-title {
+    margin: 0 auto;
+  }
+
+  .about-concept-spot-headline {
+    margin: 0 0 30px 0;
+  }
 }
 
 @media screen and (max-width: 425px) {

--- a/src/tufspot/public/js/modules/about.js
+++ b/src/tufspot/public/js/modules/about.js
@@ -8,24 +8,40 @@
                 ".about-concept-title",
             );
             const hoverTextArea = document.querySelector(".hover-text-area");
-            aboutConceptTitle[0].addEventListener("mouseover", () => {
-                hoverTextArea.classList.remove("hidden");
-                hoverTextArea.classList.add("appear");
-            });
-            aboutConceptTitle[0].addEventListener("mouseleave", () => {
-                hoverTextArea.classList.remove("appear");
-                hoverTextArea.classList.add("hidden");
+
+            var scroll;
+            var winH = $(window).height();
+            var objTop = $(".about-concept-title").offset().top;
+
+            $(window).on("scroll", function () {
+                scroll = $(window).scrollTop();
+                if (scroll >= objTop - winH / 2) {
+                    hoverTextArea.classList.remove("hidden");
+                    hoverTextArea.classList.add("appear");
+                } else {
+                    hoverTextArea.classList.remove("appear");
+                    hoverTextArea.classList.add("hidden");
+                }
             });
 
-            hoverTextArea.addEventListener("mouseover", () => {
-                hoverTextArea.classList.remove("hidden");
-                hoverTextArea.classList.add("appear");
-            });
+            // aboutConceptTitle[0].addEventListener("mouseover", () => {
+            //     hoverTextArea.classList.remove("hidden");
+            //     hoverTextArea.classList.add("appear");
+            // });
+            // aboutConceptTitle[0].addEventListener("mouseleave", () => {
+            //     hoverTextArea.classList.remove("appear");
+            //     hoverTextArea.classList.add("hidden");
+            // });
 
-            hoverTextArea.addEventListener("mouseleave", () => {
-                hoverTextArea.classList.remove("appear");
-                hoverTextArea.classList.add("hidden");
-            });
+            // hoverTextArea.addEventListener("mouseover", () => {
+            //     hoverTextArea.classList.remove("hidden");
+            //     hoverTextArea.classList.add("appear");
+            // });
+
+            // hoverTextArea.addEventListener("mouseleave", () => {
+            //     hoverTextArea.classList.remove("appear");
+            //     hoverTextArea.classList.add("hidden");
+            // });
 
             // メディアコンセプト、ホバー時テキスト入れ替え
             switchText();
@@ -38,10 +54,13 @@
                 const hoverText = document.querySelector(".hover-text");
                 if (window.innerWidth >= 992) {
                     hoverText.innerHTML =
-                        "バラバラであることを楽しみ、そこに新たな視点を見出す。<br>それが当たり前のようにできる外大同窓生に向けたメディアだからこそ、<br>「違う」ことを恐れず、自分たちが見聞きし、考えたことをシェアしよう。";
+                        "バラバラであることを楽しみ、そこに新たな視点を見出す。<br>それが当たり前のようにできる外大同窓生に向けたメディア<br>だからこそ、「違う」ことを恐れず、自分たちが見聞きし、<br>考えたことをシェアしよう。";
                 } else if (window.innerWidth >= 769) {
                     hoverText.innerHTML =
                         "バラバラであることを楽しみ、<br>そこに新たな視点を見出す。<br>それが当たり前のようにできる<br>外大同窓生に向けたメディアだからこそ、<br>「違う」ことを恐れず、<br>自分たちが見聞きし、考えたことをシェアしよう。";
+                } else if (window.innerWidth <= 531) {
+                    hoverText.innerHTML =
+                        "バラバラであることを楽しみ、<br>そこに新たな視点を見出す。<br>それが当たり前のようにできる<br>外大同窓生に向けたメディアだからこそ、<br>「違う」ことを恐れず、<br>自分たちが見聞きし、<br>考えたことをシェアしよう。";
                 }
             }
         }

--- a/src/tufspot/resources/views/about.blade.php
+++ b/src/tufspot/resources/views/about.blade.php
@@ -78,7 +78,7 @@
                 </div>
                 <div class="about-concept-spot-detail d-flex flex-column align-itemsn-center justify-content-center align-items-center">
                     <div class="about-concept-spot about-concept-spot-first d-flex flex-column justify-content-center align-items-center">
-                        <p class="about-concept-spot-title">［ ＃世界中の外大知を集める ］</p>
+                        <p class="about-concept-spot-title">＃世界中の外大知を集める</p>
                         <p class="about-concept-spot-headline">TUFS-<span>POT</span></p>
                         <div class="about-concept-spot-text-wrapper d-flex align-items-end">
                             <p class="about-concept-spot-text">
@@ -88,7 +88,7 @@
                         </div>
                     </div>
                     <div class="about-concept-spot d-flex flex-column justify-content-center align-items-center">
-                        <p class="about-concept-spot-title"><span class="about_br">［ </span>＃外大生の知見にスポットを当てる<span class="about_br"> ］</span></p>
+                        <p class="about-concept-spot-title"><span class="about_br"></span>＃外大生の知見にスポットを当てる<span class="about_br"></span></p>
                         <p class="about-concept-spot-headline">TUF-<span>SPOT</span></p>
                         <div class="about-concept-spot-text-wrapper d-flex align-items-end">
                             <p class="about-concept-spot-text spot">

--- a/src/tufspot/resources/views/about.blade.php
+++ b/src/tufspot/resources/views/about.blade.php
@@ -78,7 +78,7 @@
                 </div>
                 <div class="about-concept-spot-detail d-flex flex-column align-itemsn-center justify-content-center align-items-center">
                     <div class="about-concept-spot about-concept-spot-first d-flex flex-column justify-content-center align-items-center">
-                        <p class="about-concept-spot-title">［　世界中の外大知を集める　］</p>
+                        <p class="about-concept-spot-title">［ ＃世界中の外大知を集める ］</p>
                         <p class="about-concept-spot-headline">TUFS-<span>POT</span></p>
                         <div class="about-concept-spot-text-wrapper d-flex align-items-end">
                             <p class="about-concept-spot-text">
@@ -88,7 +88,7 @@
                         </div>
                     </div>
                     <div class="about-concept-spot d-flex flex-column justify-content-center align-items-center">
-                        <p class="about-concept-spot-title"><span class="about_br">［　</span>外大生の知見にスポットを当てる<span class="about_br">　］</span></p>
+                        <p class="about-concept-spot-title"><span class="about_br">［ </span>＃外大生の知見にスポットを当てる<span class="about_br"> ］</span></p>
                         <p class="about-concept-spot-headline">TUF-<span>SPOT</span></p>
                         <div class="about-concept-spot-text-wrapper d-flex align-items-end">
                             <p class="about-concept-spot-text spot">

--- a/src/tufspot/resources/views/about.blade.php
+++ b/src/tufspot/resources/views/about.blade.php
@@ -35,20 +35,20 @@
     </div>
     <x-main>
         <div class="about-wrapper d-flex flex-column align-items-center">
-            <div class="about-concept">
-                <div class="about-concept-title d-flex justify-content-center align-items-center">
-                    メディアコンセプト
-                </div>
-                <div class="about-concept-text hover d-flex justify-content-center align-items-center">
-                    Enjoy Diversity
-                </div>
-                <div class="hover-text-area">
-                    <p class="hover-text">バラバラであることを楽しみ、そこに新たな視点を見出す。<br>それが当たり前のようにできる外大同窓生に向けたメディアだからこそ、<br>「違う」ことを恐れず、自分たちが見聞きし、考えたことをシェアしよう。</p>
+            <div class="about-concept" style="height: 300px">
+                <div class="w-100 m-auto position-relative position-absolute" style="max-width: 625px; left: 50%; transform: translate(-50%);">
+                    <div class="about-concept-title d-flex justify-content-center align-items-center">
+                        メディアコンセプト
+                    </div>
+                    <div class="about-concept-text hover d-flex justify-content-center align-items-center">
+                        Enjoy Diversity
+                    </div>
+                    <div class="hover-text-area hidden">
+                        <p class="hover-text">バラバラであることを楽しみ、そこに新たな視点を見出す。<br>それが当たり前のようにできる外大同窓生に向けたメディアだからこそ、<br>「違う」ことを恐れず、自分たちが見聞きし、考えたことをシェアしよう。</p>
+                    </div>
                 </div>
             </div>
-            <p class="about-theme-top-text">
-                ［　主に取り扱う3つのテーマ　］
-            </p>
+            <p class="about-theme-top-text"> ［　主に取り扱う3つのテーマ　］</p>
             <div class="about-theme-wrapper d-flex">
                 <div class="about-theme d-flex flex-column align-items-center">
                     <p class="about-theme-title text-center"><span>A</span>cademia</p>


### PR DESCRIPTION
## [About 行間等々#140](https://github.com/Tatsuya-328/tufspot_develop/issues/140)

- [x] 一番上の説明の行間を1.5倍にする
- [x] AcademiaとBusiness,,,とで説明文の横幅を揃える
- [x] 「,...3つのテーマ」とAcademia,,,の要素等の間の余白を1.5倍にする

## [About TUFSPOTとは修正#142](https://github.com/Tatsuya-328/tufspot_develop/issues/142)

- [x] 見出しを左揃えにする
- [x] 「世界中の外大知を集める」→＃世界中の外大知を集める
- [x] 「外大生の知見にスポットを当てる」→＃外大生の知見にスポットを当てる

## [About、メディアコンセプトの修正#141](https://github.com/Tatsuya-328/tufspot_develop/issues/141)

- [x] メディアコンセプトの縦横比率だいたいそのままで大きさを半分に
- [x] メディアコンセプトの要素がセンターに来るように調整
- [x] スクロールして画面真ん中あたりにくると、自動でhover状態と同じく切り替わるように
    - 「[Aboutのレスポンシブ時のHover修正#93](https://github.com/Tatsuya-328/tufspot_develop/issues/93)とやりたいことは同じで、768px以下以外=全てのウィンドウサイズでも対応させる」と、解釈しました
    - 勝手に元のHover時の処理を消して、スクロールだけ変化させるようにしたけどどうだろ？？
    - もし、Hover時とスクロール時の処理を両立させたいなら、「それぞれの条件が○○のとき△△にしたい」みたいな簡易仕様書みたいなのあれば助かります！