### PR TITLE
カテゴリー記事一覧のヘッダー修正

### DIFF
--- a/src/tufspot/public/css/style_uru.css
+++ b/src/tufspot/public/css/style_uru.css
@@ -248,9 +248,9 @@ footer {
   min-height: 130px;
   /* align-items: center; */
   /* justify-content: center; */
-  margin: 0 0 45px 0;
+  /* margin: 0 0 45px 0; */
   /* 上に影出さないため、overflow */
-  box-shadow: 0px 4px 5.5px #d3d3d3;
+  /* box-shadow: 0px 4px 5.5px #d3d3d3; */
   overflow: hidden;
 }
 
@@ -280,7 +280,7 @@ footer {
 }
 
 .post_list_explain {
-  margin: 0 auto 80px auto;
+  margin: 0 auto 120px auto;
   max-width: 780px;
   padding: 0 20px;
 }


### PR DESCRIPTION
#138

ヘッダーの下線を削除して、説明文をタイトルの真下に置きました

 ![Image](https://github.com/Tatsuya-328/tufspot_develop/assets/84480954/df726455-cb23-4cf2-83e0-30fd528ecf3b)

![image](https://github.com/Tatsuya-328/tufspot_develop/assets/82076335/ddcd2367-b154-4f29-a34b-132432e3b080)
