### PR TITLE
[LINEでの追加要件] ログインボタンが状態変化するトリガーを変更

### DIFF
--- a/src/tufspot/resources/js/app.js
+++ b/src/tufspot/resources/js/app.js
@@ -4,7 +4,7 @@ $(function () {
     $("#submit_button").prop("disabled", true);
 
     // 入力欄の操作時
-    $("form input:required").change(function () {
+    $("form input:required").keyup(function () {
         let isAllFormsFilled = false;
 
         // すべての入力必須欄が埋まった場合に、isAllFormsFilledをTrueへ


### PR DESCRIPTION
ログイン/新規登録ページに関して

必須部の入力を
"入力完了時点"ではなく"入力開始した時点"にボタンの状態を変化するように変更。

ここの部分
![image](https://github.com/Tatsuya-328/tufspot_develop/assets/82076335/ff9c705d-bbce-45bc-a8f1-61c7397d8cfd)

新規登録画面でも同様の動作をするようになっています！